### PR TITLE
Python native fixes

### DIFF
--- a/h5ffmpeg/__init__.py
+++ b/h5ffmpeg/__init__.py
@@ -13,7 +13,6 @@ import warnings
 import logging
 import traceback
 import ctypes
-import functools
 
 # Set environment variable to hide svtav1 info logging
 os.environ["SVT_LOG"] = "1"

--- a/h5ffmpeg/__init__.py
+++ b/h5ffmpeg/__init__.py
@@ -15,6 +15,9 @@ import traceback
 import ctypes
 import functools
 
+# Set environment variable to hide svtav1 info logging
+os.environ["SVT_LOG"] = "1"
+
 logger = logging.getLogger(__name__)
 
 try:

--- a/h5ffmpeg/__init__.py
+++ b/h5ffmpeg/__init__.py
@@ -22,12 +22,12 @@ logger = logging.getLogger(__name__)
 
 try:
     from ._ffmpeg_filter import (
-        register_filter, 
+        register_filter,
         get_filter_id,
     )
 
     FFMPEG_ID = get_filter_id()
-    
+
     # Initialize registration status
     HAS_EXTENSION = True
 except ImportError as e:
@@ -41,6 +41,7 @@ except ImportError as e:
     FFMPEG_ID = 32030
     HAS_EXTENSION = False
 
+
 # Register the filter with HDF5 and h5py
 def _register_with_h5py():
     """Register the FFMPEG filter with HDF5 and h5py"""
@@ -52,37 +53,40 @@ def _register_with_h5py():
         try:
             result = register_filter()
             if result < 0:
-                logger.error(f"Failed to register FFMPEG filter with HDF5: error code {result}")
+                logger.error(
+                    f"Failed to register FFMPEG filter with HDF5: error code {result}"
+                )
                 return False
         except Exception as e:
             logger.error(f"Error registering FFMPEG filter with HDF5: {str(e)}")
             return False
-            
+
         import h5py
-        
+
         try:
             # Find our extension module file
             module_path = None
             module_dir = os.path.dirname(os.path.abspath(__file__))
-            
+
             # Find the extension file
-            if sys.platform.startswith('win'):
+            if sys.platform.startswith("win"):
                 ext_pattern = "_ffmpeg_filter*.pyd"
-            elif sys.platform.startswith('darwin'):
+            elif sys.platform.startswith("darwin"):
                 ext_pattern = "_ffmpeg_filter*.so"
             else:
                 ext_pattern = "_ffmpeg_filter*.so"
-                
+
             import glob
+
             ext_files = glob.glob(os.path.join(module_dir, ext_pattern))
-            
+
             if not ext_files:
                 logger.error(f"Could not find extension module in {module_dir}")
                 return False
-                
+
             module_path = ext_files[0]
             logger.info(f"Found extension module at: {module_path}")
-            
+
             # Load the module as a shared library
             try:
                 lib = ctypes.CDLL(module_path)
@@ -91,43 +95,50 @@ def _register_with_h5py():
                 logger.error(f"Failed to load extension as shared library: {str(e)}")
                 logger.error(traceback.format_exc())
                 return False
-                
+
             # Check if H5PLget_plugin_info exists
-            if not hasattr(lib, 'H5PLget_plugin_info'):
-                logger.error("H5PLget_plugin_info function not found in extension module")
+            if not hasattr(lib, "H5PLget_plugin_info"):
+                logger.error(
+                    "H5PLget_plugin_info function not found in extension module"
+                )
                 return False
-                
+
             # Set the correct return type
             lib.H5PLget_plugin_info.restype = ctypes.c_void_p
-            
+
             # Call the function and register with h5py
             try:
                 plugin_info_ptr = lib.H5PLget_plugin_info()
                 if not plugin_info_ptr:
                     logger.error("H5PLget_plugin_info() returned NULL")
                     return False
-                    
+
                 logger.info(f"Got plugin info pointer: {plugin_info_ptr}")
-                
+
                 # Register with h5py
                 h5py.h5z.register_filter(plugin_info_ptr)
-                logger.info(f"Successfully registered FFMPEG filter (ID: {FFMPEG_ID}) with h5py")
+                logger.info(
+                    f"Successfully registered FFMPEG filter (ID: {FFMPEG_ID}) with h5py"
+                )
                 return True
-                
+
             except Exception as e:
-                logger.error(f"Error calling H5PLget_plugin_info or registering filter: {str(e)}")
+                logger.error(
+                    f"Error calling H5PLget_plugin_info or registering filter: {str(e)}"
+                )
                 logger.error(traceback.format_exc())
                 return False
-                
+
         except Exception as e:
             logger.error(f"Failed to register FFMPEG filter with h5py: {str(e)}")
             logger.error(traceback.format_exc())
             return False
-            
+
     except Exception as e:
         logger.error(f"Unexpected error registering FFMPEG filter: {str(e)}")
         logger.error(traceback.format_exc())
         return False
+
 
 # Attempt to register the filter
 if HAS_EXTENSION:
@@ -145,23 +156,57 @@ else:
 # Import the other modules
 from .ffmpeg_filter import (
     # Main API functions
-    ffmpeg, mpeg4, x264, x265, rav1e, svtav1, h264_nvenc, hevc_nvenc, av1_nvenc, av1_qsv,
-
+    ffmpeg,
+    mpeg4,
+    x264,
+    x265,
+    rav1e,
+    svtav1,
+    h264_nvenc,
+    hevc_nvenc,
+    av1_nvenc,
+    av1_qsv,
     # native ones
-    ffmpeg_native, compress_native, decompress_native, NATIVE_AVAILABLE,
-    
+    ffmpeg_native,
+    compress_native,
+    decompress_native,
+    NATIVE_AVAILABLE,
     # Classes for constants and enum values
-    EncoderCodec, DecoderCodec, Preset, Tune, BitMode,
-    
+    EncoderCodec,
+    DecoderCodec,
+    Preset,
+    Tune,
+    BitMode,
     # Helper functions for hardware detection
-    has_nvidia_gpu, has_intel_gpu
+    has_nvidia_gpu,
+    has_intel_gpu,
 )
 
 from .anm import film_grain_optimizer
 
 __all__ = [
-    'ffmpeg', 'mpeg4', 'x264', 'x265', 'svtav1', 'rav1e', 'h264_nvenc', 'hevc_nvenc', 'av1_nvenc', 'av1_qsv',
-    'EncoderCodec', 'DecoderCodec', 'Preset', 'Tune', 'BitMode', 'has_nvidia_gpu', 'has_intel_gpu', 
-    'FFMPEG_ID', 'film_grain_optimizer', 'FILTER_REGISTERED',
-    'ffmpeg_native', 'compress_native', 'decompress_native', 'NATIVE_AVAILABLE'
+    "ffmpeg",
+    "mpeg4",
+    "x264",
+    "x265",
+    "svtav1",
+    "rav1e",
+    "h264_nvenc",
+    "hevc_nvenc",
+    "av1_nvenc",
+    "av1_qsv",
+    "EncoderCodec",
+    "DecoderCodec",
+    "Preset",
+    "Tune",
+    "BitMode",
+    "has_nvidia_gpu",
+    "has_intel_gpu",
+    "FFMPEG_ID",
+    "film_grain_optimizer",
+    "FILTER_REGISTERED",
+    "ffmpeg_native",
+    "compress_native",
+    "decompress_native",
+    "NATIVE_AVAILABLE",
 ]

--- a/h5ffmpeg/anm.py
+++ b/h5ffmpeg/anm.py
@@ -13,96 +13,117 @@ import warnings
 
 warnings.filterwarnings("ignore")
 
+
 def normalize(img):
     return img / np.max(img)
 
+
 def analyze_content(img):
     img_norm = normalize(img)
-    
+
     if img_norm.ndim == 3:
         mid_z = img_norm.shape[0] // 2
         img_analysis = img_norm[mid_z]
     else:
         img_analysis = img_norm
-    
+
     try:
         thresh = threshold_otsu(img_analysis)
         binary = img_analysis > thresh
         structure_density = np.mean(binary)
     except:
-        structure_density = np.sum(img_analysis > np.mean(img_analysis)) / img_analysis.size
-    
-    background = img_analysis * (1 - binary) if 'binary' in locals() else img_analysis * (img_analysis < np.percentile(img_analysis, 25))
+        structure_density = (
+            np.sum(img_analysis > np.mean(img_analysis)) / img_analysis.size
+        )
+
+    background = (
+        img_analysis * (1 - binary)
+        if "binary" in locals()
+        else img_analysis * (img_analysis < np.percentile(img_analysis, 25))
+    )
     background_pixels = background[background > 0]
-    background_uniformity = 1 - np.std(background_pixels) if len(background_pixels) > 0 else 0.5
-    
+    background_uniformity = (
+        1 - np.std(background_pixels) if len(background_pixels) > 0 else 0.5
+    )
+
     from scipy import ndimage
+
     gx = ndimage.sobel(img_analysis, axis=1)
     gy = ndimage.sobel(img_analysis, axis=0)
     gradient_mag = np.hypot(gx, gy)
     detail_level = np.percentile(gradient_mag / np.max(gradient_mag), 75)
-    
+
     return {
-        'structure_density': structure_density,
-        'background_uniformity': background_uniformity,
-        'detail_level': detail_level
+        "structure_density": structure_density,
+        "background_uniformity": background_uniformity,
+        "detail_level": detail_level,
     }
+
 
 def extract_patches(img, num_samples=5, patch_size=(32, 128, 128)):
     z, h, w = img.shape
     patch_z, patch_h, patch_w = patch_size
-    
+
     patch_z = min(patch_z, z)
     patch_h = min(patch_h, h)
     patch_w = min(patch_w, w)
-    
+
     mid_z = z // 2
     analysis_slice = img[mid_z]
-    
+
     edges = feature.canny(analysis_slice, sigma=1.5)
     texture = generic_filter(analysis_slice, np.std, size=7)
-    
+
     detail_map_2d = edges * 2 + texture / np.max(texture)
     detail_map_2d = detail_map_2d / np.max(detail_map_2d)
-    
+
     z_gradient = np.abs(np.diff(img, axis=0))
     z_variation = np.mean(z_gradient, axis=0)
     z_variation = z_variation / np.max(z_variation)
-    
+
     detail_map_3d = detail_map_2d + z_variation
     detail_map_3d = detail_map_3d / np.max(detail_map_3d)
-    
+
     high_detail = detail_map_3d > np.percentile(detail_map_3d, 75)
-    
+
     patches = []
     high_detail_coords = np.argwhere(high_detail)
     np.random.shuffle(high_detail_coords)
     high_detail_samples = min(int(num_samples * 0.7), len(high_detail_coords))
-    
+
     for i in range(high_detail_samples):
         if i < len(high_detail_coords):
             y, x = high_detail_coords[i]
-            
+
             z_start = np.random.randint(0, max(1, z - patch_z + 1))
-            y_start = min(max(0, y - patch_h//2), h - patch_h)
-            x_start = min(max(0, x - patch_w//2), w - patch_w)
-            
-            patch = img[z_start:z_start+patch_z, y_start:y_start+patch_h, x_start:x_start+patch_w]
+            y_start = min(max(0, y - patch_h // 2), h - patch_h)
+            x_start = min(max(0, x - patch_w // 2), w - patch_w)
+
+            patch = img[
+                z_start : z_start + patch_z,
+                y_start : y_start + patch_h,
+                x_start : x_start + patch_w,
+            ]
             patches.append(patch)
-    
+
     remaining_samples = num_samples - len(patches)
     for _ in range(remaining_samples):
         z_start = np.random.randint(0, z - patch_z + 1)
         y_start = np.random.randint(0, h - patch_h + 1)
         x_start = np.random.randint(0, w - patch_w + 1)
-        patch = img[z_start:z_start+patch_z, y_start:y_start+patch_h, x_start:x_start+patch_w]
+        patch = img[
+            z_start : z_start + patch_z,
+            y_start : y_start + patch_h,
+            x_start : x_start + patch_w,
+        ]
         patches.append(patch)
-    
+
     return np.stack(patches, axis=0)
+
 
 def detect_blockiness(img, block_sizes=[8, 16]):
     img_norm = normalize(img)
-    
+
     if img_norm.ndim == 4:
         total_score = 0
         for i in range(img_norm.shape[0]):
@@ -111,87 +132,98 @@ def detect_blockiness(img, block_sizes=[8, 16]):
             channel = patch[mid_z]
             total_score += _detect_blockiness_single(channel, block_sizes)
         return total_score / img_norm.shape[0]
-    
+
     elif img_norm.ndim == 3:
         mid_z = img_norm.shape[0] // 2
         channel = img_norm[mid_z]
     else:
         channel = img_norm
-    
+
     return _detect_blockiness_single(channel, block_sizes)
+
 
 def _detect_blockiness_single(channel, block_sizes):
     gx = np.abs(np.diff(channel, axis=1, prepend=channel[:, :1]))
     gy = np.abs(np.diff(channel, axis=0, prepend=channel[:1, :]))
-    
+
     block_score = 0
     for block_size in block_sizes:
-        h_pattern = np.mean(gx[:, block_size-1::block_size])
-        h_non_pattern = np.mean(np.delete(gx, np.arange(block_size-1, gx.shape[1], block_size), axis=1))
+        h_pattern = np.mean(gx[:, block_size - 1 :: block_size])
+        h_non_pattern = np.mean(
+            np.delete(gx, np.arange(block_size - 1, gx.shape[1], block_size), axis=1)
+        )
         h_ratio = h_pattern / (h_non_pattern + 1e-8)
-        
-        v_pattern = np.mean(gy[block_size-1::block_size, :])
-        v_non_pattern = np.mean(np.delete(gy, np.arange(block_size-1, gy.shape[0], block_size), axis=0))
+
+        v_pattern = np.mean(gy[block_size - 1 :: block_size, :])
+        v_non_pattern = np.mean(
+            np.delete(gy, np.arange(block_size - 1, gy.shape[0], block_size), axis=0)
+        )
         v_ratio = v_pattern / (v_non_pattern + 1e-8)
-        
+
         block_score += max(0, h_ratio - 1.2) + max(0, v_ratio - 1.2)
-    
+
     def dct_blockiness(img, block_size=8):
         h, w = img.shape
         score = 0
-        
-        for i in range(0, h-block_size, block_size):
-            for j in range(0, w-block_size, block_size):
-                block = img[i:i+block_size, j:j+block_size]
-                dct_block = dct(dct(block.T, norm='ortho').T, norm='ortho')
+
+        for i in range(0, h - block_size, block_size):
+            for j in range(0, w - block_size, block_size):
+                block = img[i : i + block_size, j : j + block_size]
+                dct_block = dct(dct(block.T, norm="ortho").T, norm="ortho")
                 high_freq = np.abs(dct_block[4:, 4:])
                 low_freq = np.abs(dct_block[:4, :4])
-                
+
                 if np.mean(high_freq) > 0.05 * np.mean(low_freq):
                     score += 1
-        
-        blocks_analyzed = ((h // block_size) * (w // block_size))
+
+        blocks_analyzed = (h // block_size) * (w // block_size)
         return score / max(1, blocks_analyzed)
-    
+
     dct_score = dct_blockiness(channel)
-    
+
     smooth = gaussian(channel, sigma=0.5)
     diff = np.abs(channel - smooth)
-    
-    h_disc = np.sum(np.mean(diff[:, block_sizes[0]-1::block_sizes[0]], axis=1))
-    v_disc = np.sum(np.mean(diff[block_sizes[0]-1::block_sizes[0], :], axis=0))
-    
+
+    h_disc = np.sum(np.mean(diff[:, block_sizes[0] - 1 :: block_sizes[0]], axis=1))
+    v_disc = np.sum(np.mean(diff[block_sizes[0] - 1 :: block_sizes[0], :], axis=0))
+
     h_disc /= channel.shape[0]
     v_disc /= channel.shape[1]
-    
+
     struct_score = (h_disc + v_disc) / 2
     return 0.4 * block_score + 0.4 * dct_score + 0.2 * struct_score
+
 
 def analyze_structure_preservation(original, compressed):
     if original.ndim == 4:
         boundary_scores = []
         detail_scores = []
         intensity_scores = []
-        
+
         for i in range(original.shape[0]):
             orig_patch = original[i]
             comp_patch = compressed[i]
             mid_z = orig_patch.shape[0] // 2
             orig_analysis = orig_patch[mid_z]
             comp_analysis = comp_patch[mid_z]
-            
+
             scores = _analyze_structure_single(orig_analysis, comp_analysis)
-            boundary_scores.append(scores['boundary_preservation'])
-            detail_scores.append(scores['detail_preservation'])
-            intensity_scores.append(scores['intensity_preservation'])
-        
+            boundary_scores.append(scores["boundary_preservation"])
+            detail_scores.append(scores["detail_preservation"])
+            intensity_scores.append(scores["intensity_preservation"])
+
         return {
-            'boundary_preservation': np.mean(boundary_scores),
-            'detail_preservation': np.mean(detail_scores),
-            'intensity_preservation': np.mean(intensity_scores),
-            'overall_quality': (np.mean(boundary_scores) + np.mean(detail_scores) + np.mean(intensity_scores)) / 3
+            "boundary_preservation": np.mean(boundary_scores),
+            "detail_preservation": np.mean(detail_scores),
+            "intensity_preservation": np.mean(intensity_scores),
+            "overall_quality": (
+                np.mean(boundary_scores)
+                + np.mean(detail_scores)
+                + np.mean(intensity_scores)
+            )
+            / 3,
         }
-    
+
     if original.ndim == 3:
         mid_z = original.shape[0] // 2
         orig_analysis = original[mid_z]
@@ -199,250 +231,306 @@ def analyze_structure_preservation(original, compressed):
     else:
         orig_analysis = original
         comp_analysis = compressed
-    
+
     return _analyze_structure_single(orig_analysis, comp_analysis)
+
 
 def _analyze_structure_single(orig_analysis, comp_analysis):
     orig_norm = orig_analysis / np.max(orig_analysis)
     comp_norm = comp_analysis / np.max(comp_analysis)
-    
+
     edges_orig = feature.canny(orig_norm, sigma=1.0)
     edges_comp = feature.canny(comp_norm, sigma=1.0)
-    
+
     true_positive = np.sum(edges_orig & edges_comp)
     false_negative = np.sum(edges_orig & ~edges_comp)
     false_positive = np.sum(~edges_orig & edges_comp)
-    
+
     precision = true_positive / (true_positive + false_positive + 1e-10)
     recall = true_positive / (true_positive + false_negative + 1e-10)
     f1_boundary = 2 * (precision * recall) / (precision + recall + 1e-10)
-    
+
     orig_smooth = gaussian_filter(orig_norm, sigma=2.0)
     comp_smooth = gaussian_filter(comp_norm, sigma=2.0)
-    
+
     orig_detail = orig_norm - orig_smooth
     comp_detail = comp_norm - comp_smooth
-    
+
     data_range = np.max(orig_detail) - np.min(orig_detail)
     if data_range <= 0:
         data_range = 1.0
     detail_ssim = ssim(orig_detail, comp_detail, data_range=data_range)
-    
+
     try:
         thresh_orig = threshold_otsu(orig_norm)
         mask_orig = orig_norm > thresh_orig
     except:
         mask_orig = orig_norm > np.mean(orig_norm)
-    
+
     def kl_divergence(p, q):
         p = p + 1e-10
         q = q + 1e-10
         p = p / np.sum(p)
         q = q / np.sum(q)
         return np.sum(p * np.log(p / q))
-    
+
     hist_orig, bins = np.histogram(orig_norm[mask_orig], bins=50, density=True)
     hist_comp, _ = np.histogram(comp_norm[mask_orig], bins=bins, density=True)
-    
-    if len(hist_orig) > 0 and len(hist_comp) > 0 and np.sum(hist_orig) > 0 and np.sum(hist_comp) > 0:
-        kl_div = (kl_divergence(hist_orig, hist_comp) + kl_divergence(hist_comp, hist_orig)) / 2
+
+    if (
+        len(hist_orig) > 0
+        and len(hist_comp) > 0
+        and np.sum(hist_orig) > 0
+        and np.sum(hist_comp) > 0
+    ):
+        kl_div = (
+            kl_divergence(hist_orig, hist_comp) + kl_divergence(hist_comp, hist_orig)
+        ) / 2
         intensity_similarity = np.exp(-kl_div)
     else:
         intensity_similarity = 0.5
-    
+
     return {
-        'boundary_preservation': f1_boundary,
-        'detail_preservation': detail_ssim,
-        'intensity_preservation': intensity_similarity,
-        'overall_quality': (f1_boundary + detail_ssim + intensity_similarity) / 3
+        "boundary_preservation": f1_boundary,
+        "detail_preservation": detail_ssim,
+        "intensity_preservation": intensity_similarity,
+        "overall_quality": (f1_boundary + detail_ssim + intensity_similarity) / 3,
     }
+
 
 def plot_results(grains, blockiness, perceptual, compression, combined, best_grain):
     plt.figure(figsize=(14, 10))
     gs = plt.GridSpec(2, 2, height_ratios=[1, 1])
-    
+
     ax1 = plt.subplot(gs[0, 0])
-    ax1.plot(grains, blockiness, 'ro-', linewidth=2, markersize=6)
-    ax1.set_ylabel('Blockiness Score\n(lower is better)', fontsize=10)
-    ax1.set_title('Artifact Detection', fontsize=12)
+    ax1.plot(grains, blockiness, "ro-", linewidth=2, markersize=6)
+    ax1.set_ylabel("Blockiness Score\n(lower is better)", fontsize=10)
+    ax1.set_title("Artifact Detection", fontsize=12)
     ax1.grid(True, alpha=0.3)
-    
+
     ax2 = plt.subplot(gs[0, 1])
-    ax2.plot(grains, perceptual, 'go-', linewidth=2, markersize=6)
-    ax2.set_ylabel('Perceptual Quality\n(higher is better)', fontsize=10)
-    ax2.set_title('Structure Preservation', fontsize=12)
+    ax2.plot(grains, perceptual, "go-", linewidth=2, markersize=6)
+    ax2.set_ylabel("Perceptual Quality\n(higher is better)", fontsize=10)
+    ax2.set_title("Structure Preservation", fontsize=12)
     ax2.grid(True, alpha=0.3)
-    
+
     ax3 = plt.subplot(gs[1, 0])
-    ax3.plot(grains, combined, 'bo-', linewidth=2, markersize=6)
-    ax3.axvline(x=best_grain, color='black', linestyle='--', linewidth=2, 
-                label=f'Best grain: {best_grain}')
-    ax3.set_xlabel('Film Grain Parameter', fontsize=10)
-    ax3.set_ylabel('Combined Score\n(higher is better)', fontsize=10)
-    ax3.set_title('Overall Quality', fontsize=12)
+    ax3.plot(grains, combined, "bo-", linewidth=2, markersize=6)
+    ax3.axvline(
+        x=best_grain,
+        color="black",
+        linestyle="--",
+        linewidth=2,
+        label=f"Best grain: {best_grain}",
+    )
+    ax3.set_xlabel("Film Grain Parameter", fontsize=10)
+    ax3.set_ylabel("Combined Score\n(higher is better)", fontsize=10)
+    ax3.set_title("Overall Quality", fontsize=12)
     ax3.grid(True, alpha=0.3)
     ax3.legend(fontsize=10)
-    
+
     ax4 = plt.subplot(gs[1, 1])
-    ax4.plot(grains, compression, 'mo-', linewidth=2, markersize=6)
-    ax4.axvline(x=best_grain, color='black', linestyle='--', linewidth=2)
-    ax4.set_xlabel('Film Grain Parameter', fontsize=10)
-    ax4.set_ylabel('Compression Ratio\n(higher is better)', fontsize=10)
-    ax4.set_title('Storage Efficiency', fontsize=12)
+    ax4.plot(grains, compression, "mo-", linewidth=2, markersize=6)
+    ax4.axvline(x=best_grain, color="black", linestyle="--", linewidth=2)
+    ax4.set_xlabel("Film Grain Parameter", fontsize=10)
+    ax4.set_ylabel("Compression Ratio\n(higher is better)", fontsize=10)
+    ax4.set_title("Storage Efficiency", fontsize=12)
     ax4.grid(True, alpha=0.3)
-    
-    ax1.annotate(f'Min: {min(blockiness):.3f}', 
-                xy=(grains[np.argmin(blockiness)], min(blockiness)),
-                xytext=(grains[np.argmin(blockiness)]+2, min(blockiness)*1.1),
-                arrowprops=dict(facecolor='black', shrink=0.05, width=1),
-                fontsize=9)
-    
-    ax2.annotate(f'Max: {max(perceptual):.3f}', 
-                xy=(grains[np.argmax(perceptual)], max(perceptual)),
-                xytext=(grains[np.argmax(perceptual)]+2, max(perceptual)*0.95),
-                arrowprops=dict(facecolor='black', shrink=0.05, width=1),
-                fontsize=9)
-    
-    os.makedirs('tmp', exist_ok=True)
+
+    ax1.annotate(
+        f"Min: {min(blockiness):.3f}",
+        xy=(grains[np.argmin(blockiness)], min(blockiness)),
+        xytext=(grains[np.argmin(blockiness)] + 2, min(blockiness) * 1.1),
+        arrowprops=dict(facecolor="black", shrink=0.05, width=1),
+        fontsize=9,
+    )
+
+    ax2.annotate(
+        f"Max: {max(perceptual):.3f}",
+        xy=(grains[np.argmax(perceptual)], max(perceptual)),
+        xytext=(grains[np.argmax(perceptual)] + 2, max(perceptual) * 0.95),
+        arrowprops=dict(facecolor="black", shrink=0.05, width=1),
+        fontsize=9,
+    )
+
+    os.makedirs("tmp", exist_ok=True)
     plt.tight_layout()
-    plt.savefig('tmp/grain_optimization.png', dpi=150)
+    plt.savefig("tmp/grain_optimization.png", dpi=150)
     plt.close()
 
-def film_grain_optimizer(img=None, num_samples=5, quality_focus='artifacts', crf=30, th=0.015, norm=False, plot=False):
+
+def film_grain_optimizer(
+    img=None,
+    num_samples=5,
+    quality_focus="artifacts",
+    crf=30,
+    th=0.015,
+    norm=False,
+    plot=False,
+):
     def fn(x, a, b, c):
         return a * np.exp(-b * x) + c
+
     def fit_fn(x, popt):
         return popt[0] * np.exp(-popt[1] * x) + popt[2]
+
     def derivative(x, popt):
         return -popt[0] * popt[1] * np.exp(-popt[1] * x)
-    
+
     if img is None:
         raise ValueError("img must be provided")
-    
+
     print(f"Analyzing image of shape {img.shape}...")
-    
+
     content_info = analyze_content(img)
     print("\nContent Analysis:")
     for key, value in content_info.items():
         print(f"  - {key}: {value:.3f}")
-    
+
     print(f"\nExtracting {num_samples} representative patches...")
     img_patches = extract_patches(img, num_samples=num_samples)
-    
-    if content_info['detail_level'] > 0.7:
+
+    if content_info["detail_level"] > 0.7:
         grain_range = range(0, 31, 3)
         print("High detail content detected - using fine parameter sweep")
-    elif content_info['background_uniformity'] > 0.8:
+    elif content_info["background_uniformity"] > 0.8:
         grain_range = range(5, 51, 5)
         print("Uniform background detected - optimizing to prevent banding")
     else:
         grain_range = range(0, 51, 5)
         print("Mixed content detected - using standard parameter range")
-    
+
     print(f"Testing grain parameters: {list(grain_range)}")
-    
+
     original_patches = img_patches.copy()
     params = [hf.svtav1(film_grain=grain, crf=crf, norm=norm) for grain in grain_range]
-    
+
     blockiness_scores = []
     compression_ratios = []
     perceptual_scores = []
     structure_scores = []
-    
+
     raw_blockiness = detect_blockiness(original_patches)
     blockiness_scores.append(raw_blockiness)
     print(f"Raw blockiness score: {raw_blockiness:.4f}")
 
-    if quality_focus == 'artifacts':
-        weights = {'blockiness': 0.9, 'perceptual': 0.05, 'structure': 0.05}
+    if quality_focus == "artifacts":
+        weights = {"blockiness": 0.9, "perceptual": 0.05, "structure": 0.05}
         print("\nOptimizing for artifacts similarity")
-    elif quality_focus == 'structures':
-        weights = {'blockiness': 0.3, 'perceptual': 0.3, 'structure': 0.4}
+    elif quality_focus == "structures":
+        weights = {"blockiness": 0.3, "perceptual": 0.3, "structure": 0.4}
         print("\nOptimizing for structure preservation")
-    elif quality_focus == 'background':
-        weights = {'blockiness': 0.5, 'perceptual': 0.4, 'structure': 0.1}
+    elif quality_focus == "background":
+        weights = {"blockiness": 0.5, "perceptual": 0.4, "structure": 0.1}
         print("\nOptimizing for artifact reduction")
     else:
-        weights = {'blockiness': 0.4, 'perceptual': 0.3, 'structure': 0.3}
+        weights = {"blockiness": 0.4, "perceptual": 0.3, "structure": 0.3}
         print("\nUsing balanced approach")
-    
+
     print("\nTesting parameters:")
-    print(f"{'Grain':<6} {'Score':<8} {'Blockiness':<12} {'SSIM':<12} {'Structure':<12} {'Ratio':<8}")
+    print(
+        f"{'Grain':<6} {'Score':<8} {'Blockiness':<12} {'SSIM':<12} {'Structure':<12} {'Ratio':<8}"
+    )
     print("-" * 50)
-    
+
     for i, param in enumerate(params):
         all_decom_patches = []
         total_cs_ratio = 0
-        
+
         for j in range(img_patches.shape[0]):
             patch = img_patches[j]
             decom_patch, cs_ratio, _, _, _ = compress_and_decompress(patch, param)
             all_decom_patches.append(decom_patch)
             total_cs_ratio += cs_ratio
-        
+
         decom_data = np.stack(all_decom_patches, axis=0)
         avg_cs_ratio = total_cs_ratio / img_patches.shape[0]
         compression_ratios.append(avg_cs_ratio)
-        
+
         block_score = detect_blockiness(decom_data)
         blockiness_scores.append(block_score)
 
         original_patches = original_patches.astype(np.float32)
         decom_data = decom_data.astype(np.float32)
-        
+
         if original_patches.ndim == 4:
             ssim_scores = []
             for j in range(original_patches.shape[0]):
                 orig_patch = original_patches[j]
                 comp_patch = decom_data[j]
                 mid_z = orig_patch.shape[0] // 2
-                ssim_score = ssim(orig_patch[mid_z], comp_patch[mid_z], data_range=np.amax(orig_patch[mid_z])-np.amin(orig_patch[mid_z]))
+                ssim_score = ssim(
+                    orig_patch[mid_z],
+                    comp_patch[mid_z],
+                    data_range=np.amax(orig_patch[mid_z]) - np.amin(orig_patch[mid_z]),
+                )
                 ssim_scores.append(ssim_score)
             ssim_score = np.mean(ssim_scores)
         elif original_patches.ndim == 3:
             mid_z = original_patches.shape[0] // 2
-            ssim_score = ssim(original_patches[mid_z], decom_data[mid_z], data_range=np.amax(original_patches[mid_z])-np.amin(original_patches[mid_z]))
+            ssim_score = ssim(
+                original_patches[mid_z],
+                decom_data[mid_z],
+                data_range=np.amax(original_patches[mid_z])
+                - np.amin(original_patches[mid_z]),
+            )
         else:
-            ssim_score = ssim(original_patches, decom_data, data_range=np.amax(original_patches)-np.amin(original_patches))
-        
+            ssim_score = ssim(
+                original_patches,
+                decom_data,
+                data_range=np.amax(original_patches) - np.amin(original_patches),
+            )
+
         perceptual_scores.append(ssim_score)
-        
+
         structure_metrics = analyze_structure_preservation(original_patches, decom_data)
-        structure_score = structure_metrics['overall_quality']
+        structure_score = structure_metrics["overall_quality"]
         structure_scores.append(structure_score)
-    
-    norm_blockiness = [score/blockiness_scores[0] for score in blockiness_scores[1:]]
-    
+
+    norm_blockiness = [score / blockiness_scores[0] for score in blockiness_scores[1:]]
+
     combined_scores = []
     for i in range(len(grain_range)):
-        blockiness_component = weights['blockiness'] * (1 / (1 + abs(norm_blockiness[i] - 1)))
-        score = (blockiness_component + 
-                 weights['perceptual'] * perceptual_scores[i] +
-                 weights['structure'] * structure_scores[i])
+        blockiness_component = weights["blockiness"] * (
+            1 / (1 + abs(norm_blockiness[i] - 1))
+        )
+        score = (
+            blockiness_component
+            + weights["perceptual"] * perceptual_scores[i]
+            + weights["structure"] * structure_scores[i]
+        )
         combined_scores.append(score)
 
-        print(f"{grain_range[i]:<6} {score:<8.2f} {blockiness_scores[i+1]:<12.4f} {perceptual_scores[i]:<12.4f} "
-              f"{structure_scores[i]:<12.4f} {compression_ratios[i]:<8.2f}")
-    
+        print(
+            f"{grain_range[i]:<6} {score:<8.2f} {blockiness_scores[i+1]:<12.4f} {perceptual_scores[i]:<12.4f} "
+            f"{structure_scores[i]:<12.4f} {compression_ratios[i]:<8.2f}"
+        )
+
     popt, _ = curve_fit(fn, grain_range, 1 / np.array(combined_scores))
     best_grain = np.argwhere(np.abs(derivative(range(51), popt)) < th)
     if len(best_grain) > 0:
         best_grain = best_grain[0][0]
     else:
         best_grain = 5
-    
+
     if plot:
-        plot_results(grain_range, blockiness_scores[1:], perceptual_scores, 
-                    compression_ratios, combined_scores, best_grain)
-    
+        plot_results(
+            grain_range,
+            blockiness_scores[1:],
+            perceptual_scores,
+            compression_ratios,
+            combined_scores,
+            best_grain,
+        )
+
     print(f"\nOptimal film grain parameter: {best_grain}")
-    
+
     return best_grain, {
-        'content_analysis': content_info,
-        'grain_range': list(grain_range),
-        'blockiness_scores': blockiness_scores[1:],
-        'perceptual_scores': perceptual_scores,
-        'structure_scores': structure_scores,
-        'compression_ratios': compression_ratios,
-        'combined_scores': combined_scores
+        "content_analysis": content_info,
+        "grain_range": list(grain_range),
+        "blockiness_scores": blockiness_scores[1:],
+        "perceptual_scores": perceptual_scores,
+        "structure_scores": structure_scores,
+        "compression_ratios": compression_ratios,
+        "combined_scores": combined_scores,
     }

--- a/h5ffmpeg/anm_legacy.py
+++ b/h5ffmpeg/anm_legacy.py
@@ -15,96 +15,117 @@ import warnings
 
 warnings.filterwarnings("ignore")
 
+
 def normalize(img):
     return img / np.max(img)
 
+
 def analyze_content(img):
     img_norm = normalize(img)
-    
+
     if img_norm.ndim == 3:
         mid_z = img_norm.shape[0] // 2
         img_analysis = img_norm[mid_z]
     else:
         img_analysis = img_norm
-    
+
     try:
         thresh = threshold_otsu(img_analysis)
         binary = img_analysis > thresh
         structure_density = np.mean(binary)
     except:
-        structure_density = np.sum(img_analysis > np.mean(img_analysis)) / img_analysis.size
-    
-    background = img_analysis * (1 - binary) if 'binary' in locals() else img_analysis * (img_analysis < np.percentile(img_analysis, 25))
+        structure_density = (
+            np.sum(img_analysis > np.mean(img_analysis)) / img_analysis.size
+        )
+
+    background = (
+        img_analysis * (1 - binary)
+        if "binary" in locals()
+        else img_analysis * (img_analysis < np.percentile(img_analysis, 25))
+    )
     background_pixels = background[background > 0]
-    background_uniformity = 1 - np.std(background_pixels) if len(background_pixels) > 0 else 0.5
-    
+    background_uniformity = (
+        1 - np.std(background_pixels) if len(background_pixels) > 0 else 0.5
+    )
+
     from scipy import ndimage
+
     gx = ndimage.sobel(img_analysis, axis=1)
     gy = ndimage.sobel(img_analysis, axis=0)
     gradient_mag = np.hypot(gx, gy)
     detail_level = np.percentile(gradient_mag / np.max(gradient_mag), 75)
-    
+
     return {
-        'structure_density': structure_density,
-        'background_uniformity': background_uniformity,
-        'detail_level': detail_level
+        "structure_density": structure_density,
+        "background_uniformity": background_uniformity,
+        "detail_level": detail_level,
     }
+
 
 def extract_patches(img, num_samples=5, patch_size=(32, 128, 128)):
     z, h, w = img.shape
     patch_z, patch_h, patch_w = patch_size
-    
+
     patch_z = min(patch_z, z)
     patch_h = min(patch_h, h)
     patch_w = min(patch_w, w)
-    
+
     mid_z = z // 2
     analysis_slice = img[mid_z]
-    
+
     edges = feature.canny(analysis_slice, sigma=1.5)
     texture = generic_filter(analysis_slice, np.std, size=7)
-    
+
     detail_map_2d = edges * 2 + texture / np.max(texture)
     detail_map_2d = detail_map_2d / np.max(detail_map_2d)
-    
+
     z_gradient = np.abs(np.diff(img, axis=0))
     z_variation = np.mean(z_gradient, axis=0)
     z_variation = z_variation / np.max(z_variation)
-    
+
     detail_map_3d = detail_map_2d + z_variation
     detail_map_3d = detail_map_3d / np.max(detail_map_3d)
-    
+
     high_detail = detail_map_3d > np.percentile(detail_map_3d, 75)
-    
+
     patches = []
     high_detail_coords = np.argwhere(high_detail)
     np.random.shuffle(high_detail_coords)
     high_detail_samples = min(int(num_samples * 0.7), len(high_detail_coords))
-    
+
     for i in range(high_detail_samples):
         if i < len(high_detail_coords):
             y, x = high_detail_coords[i]
-            
+
             z_start = np.random.randint(0, max(1, z - patch_z + 1))
-            y_start = min(max(0, y - patch_h//2), h - patch_h)
-            x_start = min(max(0, x - patch_w//2), w - patch_w)
-            
-            patch = img[z_start:z_start+patch_z, y_start:y_start+patch_h, x_start:x_start+patch_w]
+            y_start = min(max(0, y - patch_h // 2), h - patch_h)
+            x_start = min(max(0, x - patch_w // 2), w - patch_w)
+
+            patch = img[
+                z_start : z_start + patch_z,
+                y_start : y_start + patch_h,
+                x_start : x_start + patch_w,
+            ]
             patches.append(patch)
-    
+
     remaining_samples = num_samples - len(patches)
     for _ in range(remaining_samples):
         z_start = np.random.randint(0, z - patch_z + 1)
         y_start = np.random.randint(0, h - patch_h + 1)
         x_start = np.random.randint(0, w - patch_w + 1)
-        patch = img[z_start:z_start+patch_z, y_start:y_start+patch_h, x_start:x_start+patch_w]
+        patch = img[
+            z_start : z_start + patch_z,
+            y_start : y_start + patch_h,
+            x_start : x_start + patch_w,
+        ]
         patches.append(patch)
-    
+
     return np.stack(patches, axis=0)
+
 
 def detect_blockiness(img):
     img_norm = np.array(normalize(img) * 255, dtype=np.uint8)
-    
+
     if img_norm.ndim == 4:
         total_score = 0
         for i in range(img_norm.shape[0]):
@@ -113,100 +134,107 @@ def detect_blockiness(img):
             channel = patch[mid_z]
             total_score += _detect_blockiness_single(channel)
         return total_score / img_norm.shape[0]
-    
+
     elif img_norm.ndim == 3:
         mid_z = img_norm.shape[0] // 2
         channel = img_norm[mid_z]
     else:
         channel = img_norm
-    
+
     return _detect_blockiness_single(channel)
+
 
 def _detect_blockiness_single(img):
     block_score = 0
     for im in img:
         im = np.array(normalize(im) * 255, dtype=np.uint8)
         im = Image.fromarray(im)
-        im = ImageChops.subtract(im, im.transform(im.size, Image.Transform.AFFINE, (1,0,1,0,1,1)))
+        im = ImageChops.subtract(
+            im, im.transform(im.size, Image.Transform.AFFINE, (1, 0, 1, 0, 1, 1))
+        )
         im = np.asarray(im)
 
         im_zeros = np.zeros_like(im, np.uint8)
         # vertical and horizontal lines
-        lines = probabilistic_hough_line(im, threshold=4, line_length=10, line_gap=0, theta=np.array([-np.pi/2, 0]))
+        lines = probabilistic_hough_line(
+            im, threshold=4, line_length=10, line_gap=0, theta=np.array([-np.pi / 2, 0])
+        )
         for line in lines:
             p0, p1 = line
             rr, cc = draw.line(p0[1], p0[0], p1[1], p1[0])
             im_zeros[rr, cc] = 1
         block_score += np.sum(im_zeros)
-    
+
     return block_score
+
 
 def film_grain_optimizer(img=None, num_samples=5, crf=15, th=0.015, norm=False):
     def fn(x, a, b, c):
         return a * np.exp(-b * x) + c
+
     def fit_fn(x, popt):
         return popt[0] * np.exp(-popt[1] * x) + popt[2]
+
     def derivative(x, popt):
         return -popt[0] * popt[1] * np.exp(-popt[1] * x)
-    
+
     if img is None:
         raise ValueError("img must be provided")
-    
+
     print(f"Analyzing image of shape {img.shape}...")
-    
+
     content_info = analyze_content(img)
     print("\nContent Analysis:")
     for key, value in content_info.items():
         print(f"  - {key}: {value:.3f}")
-    
+
     print(f"\nExtracting {num_samples} representative patches...")
     img_patches = extract_patches(img, num_samples=num_samples)
-    
-    if content_info['detail_level'] > 0.7:
+
+    if content_info["detail_level"] > 0.7:
         grain_range = range(0, 31, 3)
         print("High detail content detected - using fine parameter sweep")
-    elif content_info['background_uniformity'] > 0.8:
+    elif content_info["background_uniformity"] > 0.8:
         grain_range = range(5, 51, 5)
         print("Uniform background detected - optimizing to prevent banding")
     else:
         grain_range = range(0, 51, 5)
         print("Mixed content detected - using standard parameter range")
-    
+
     print(f"Testing grain parameters: {list(grain_range)}")
-    
+
     original_patches = img_patches.copy()
     params = [hf.svtav1(film_grain=grain, crf=crf, norm=norm) for grain in grain_range]
-    
+
     blockiness_scores = []
     compression_ratios = []
-    
+
     raw_blockiness = detect_blockiness(original_patches)
     blockiness_scores.append(raw_blockiness)
     print(f"Raw blockiness score: {raw_blockiness:.4f}")
-    
+
     print("\nTesting parameters:")
     print(f"{'Grain':<6} {'Blockiness':<12} {'Ratio':<8}")
     print("-" * 50)
-    
+
     for i, param in enumerate(params):
         all_decom_patches = []
         total_cs_ratio = 0
-        
+
         for j in range(img_patches.shape[0]):
             patch = img_patches[j]
             decom_patch, cs_ratio, _, _, _ = compress_and_decompress(patch, param)
             all_decom_patches.append(decom_patch)
             total_cs_ratio += cs_ratio
-        
+
         decom_data = np.stack(all_decom_patches, axis=0)
         avg_cs_ratio = total_cs_ratio / img_patches.shape[0]
         compression_ratios.append(avg_cs_ratio)
-        
+
         block_score = detect_blockiness(decom_data)
         blockiness_scores.append(block_score)
-        
+
         print(f"{grain_range[i]:<6} {block_score:<12.4f} {avg_cs_ratio:<8.2f}")
-    
 
     blockiness_scores = np.array(blockiness_scores[1:])
     popt, _ = curve_fit(fn, grain_range, np.log(blockiness_scores))

--- a/h5ffmpeg/ffmpeg_filter.py
+++ b/h5ffmpeg/ffmpeg_filter.py
@@ -19,9 +19,11 @@ logger = logging.getLogger(__name__)
 
 FFMPEG_ID = 32030
 
+
 # Encoder codec IDs
 class EncoderCodec:
     """Encoder codec identifiers for FFMPEG HDF5 filter"""
+
     MPEG4 = 0
     XVID = 1
     X264 = 2
@@ -33,9 +35,11 @@ class EncoderCodec:
     AV1_NVENC = 8
     AV1_QSV = 9
 
+
 # Decoder codec IDs
 class DecoderCodec:
     """Decoder codec identifiers for FFMPEG HDF5 filter"""
+
     MPEG4 = 0
     H264 = 1
     H264_CUVID = 2
@@ -46,11 +50,13 @@ class DecoderCodec:
     AV1_CUVID = 7
     AV1_QSV = 8
 
+
 # Preset IDs
 class Preset:
     """Preset identifiers for FFMPEG HDF5 filter"""
+
     NONE = 0
-    
+
     # libx264 presets
     X264_ULTRAFAST = 10
     X264_SUPERFAST = 11
@@ -61,7 +67,7 @@ class Preset:
     X264_SLOW = 16
     X264_SLOWER = 17
     X264_VERYSLOW = 18
-    
+
     # h264_nvenc presets
     H264NV_FASTEST = 100
     H264NV_FASTER = 101
@@ -70,7 +76,7 @@ class Preset:
     H264NV_SLOW = 104
     H264NV_SLOWER = 105
     H264NV_SLOWEST = 106
-    
+
     # x265 presets
     X265_ULTRAFAST = 200
     X265_SUPERFAST = 201
@@ -81,7 +87,7 @@ class Preset:
     X265_SLOW = 206
     X265_SLOWER = 207
     X265_VERYSLOW = 208
-    
+
     # hevc_nvenc presets
     HEVCNV_FASTEST = 300
     HEVCNV_FASTER = 301
@@ -90,7 +96,7 @@ class Preset:
     HEVCNV_SLOW = 304
     HEVCNV_SLOWER = 305
     HEVCNV_SLOWEST = 306
-    
+
     # svtav1 presets
     SVTAV1_ULTRAFAST = 400
     SVTAV1_SUPERFAST = 401
@@ -106,7 +112,7 @@ class Preset:
     SVTAV1_MUCHSLOWER = 411
     SVTAV1_VERYSLOW = 412
     SVTAV1_SUPERSLOW = 413
-    
+
     # rav1e presets
     RAV1E_MUCHFASTER = 500
     RAV1E_FASTER = 501
@@ -119,7 +125,7 @@ class Preset:
     RAV1E_MUCHSLOWER = 508
     RAV1E_VERYSLOW = 509
     RAV1E_SUPERSLOW = 510
-    
+
     # av1_nvenc presets
     AV1NV_FASTEST = 600
     AV1NV_FASTER = 601
@@ -128,7 +134,7 @@ class Preset:
     AV1NV_SLOW = 604
     AV1NV_SLOWER = 605
     AV1NV_SLOWEST = 606
-    
+
     # av1_qsv presets
     AV1QSV_FASTEST = 700
     AV1QSV_FASTER = 701
@@ -138,11 +144,13 @@ class Preset:
     AV1QSV_SLOWER = 705
     AV1QSV_SLOWEST = 706
 
+
 # Tune IDs
 class Tune:
     """Tune identifiers for FFMPEG HDF5 filter"""
+
     NONE = 0
-    
+
     # libx264 tunes
     X264_PSNR = 10
     X264_SSIM = 11
@@ -152,13 +160,13 @@ class Tune:
     X264_ANIMATION = 15
     X264_FILM = 16
     X264_STILLIMAGE = 17
-    
+
     # h264_nvenc tunes
     H264NV_HQ = 100
     H264NV_LL = 101
     H264NV_ULL = 102
     H264NV_LOSSLESS = 103
-    
+
     # x265 tunes
     X265_PSNR = 200
     X265_SSIM = 201
@@ -166,28 +174,28 @@ class Tune:
     X265_FASTDECODE = 203
     X265_ZEROLATENCY = 204
     X265_ANIMATION = 205
-    
+
     # hevc_nvenc tunes
     HEVCNV_HQ = 300
     HEVCNV_LL = 301
     HEVCNV_ULL = 302
     HEVCNV_LOSSLESS = 303
-    
+
     # svtav1 tunes
     SVTAV1_VQ = 400
     SVTAV1_PSNR = 401
     SVTAV1_FASTDECODE = 402
-    
+
     # rav1e tunes
     RAV1E_PSNR = 500
     RAV1E_PSYCHOVISUAL = 501
-    
+
     # av1_nvenc tunes
     AV1NV_HQ = 600
     AV1NV_LL = 601
     AV1NV_ULL = 602
     AV1NV_LOSSLESS = 603
-    
+
     # av1_qsv tunes
     AV1QSV_UNKNOWN = 700
     AV1QSV_DISPLAYREMOTING = 701
@@ -199,12 +207,15 @@ class Tune:
     AV1QSV_GAMESTREAMING = 707
     AV1QSV_REMOTEGAMING = 708
 
+
 # Bit modes
 class BitMode:
     """Bit depth modes for FFMPEG HDF5 filter"""
+
     BIT_8 = 0
     BIT_10 = 1
     BIT_12 = 2
+
 
 # Mapping of codec names to encoder IDs
 CODEC_TO_ENCODER = {
@@ -217,7 +228,7 @@ CODEC_TO_ENCODER = {
     "libsvtav1": EncoderCodec.SVTAV1,
     "librav1e": EncoderCodec.RAV1E,
     "av1_nvenc": EncoderCodec.AV1_NVENC,
-    "av1_qsv": EncoderCodec.AV1_QSV
+    "av1_qsv": EncoderCodec.AV1_QSV,
 }
 
 # Mapping of codec names to decoder IDs
@@ -230,7 +241,7 @@ CODEC_TO_DECODER = {
     "libaom-av1": DecoderCodec.AOMAV1,
     "libdav1d": DecoderCodec.DAV1D,
     "av1_cuvid": DecoderCodec.AV1_CUVID,
-    "av1_qsv": DecoderCodec.AV1_QSV
+    "av1_qsv": DecoderCodec.AV1_QSV,
 }
 
 # Mapping of preset names to preset IDs for each codec
@@ -244,7 +255,7 @@ PRESET_MAPPING = {
         "medium": Preset.X264_MEDIUM,
         "slow": Preset.X264_SLOW,
         "slower": Preset.X264_SLOWER,
-        "veryslow": Preset.X264_VERYSLOW
+        "veryslow": Preset.X264_VERYSLOW,
     },
     "h264_nvenc": {
         "p1": Preset.H264NV_FASTEST,
@@ -253,7 +264,7 @@ PRESET_MAPPING = {
         "p4": Preset.H264NV_MEDIUM,
         "p5": Preset.H264NV_SLOW,
         "p6": Preset.H264NV_SLOWER,
-        "p7": Preset.H264NV_SLOWEST
+        "p7": Preset.H264NV_SLOWEST,
     },
     "libx265": {
         "ultrafast": Preset.X265_ULTRAFAST,
@@ -264,7 +275,7 @@ PRESET_MAPPING = {
         "medium": Preset.X265_MEDIUM,
         "slow": Preset.X265_SLOW,
         "slower": Preset.X265_SLOWER,
-        "veryslow": Preset.X265_VERYSLOW
+        "veryslow": Preset.X265_VERYSLOW,
     },
     "hevc_nvenc": {
         "p1": Preset.HEVCNV_FASTEST,
@@ -273,7 +284,7 @@ PRESET_MAPPING = {
         "p4": Preset.HEVCNV_MEDIUM,
         "p5": Preset.HEVCNV_SLOW,
         "p6": Preset.HEVCNV_SLOWER,
-        "p7": Preset.HEVCNV_SLOWEST
+        "p7": Preset.HEVCNV_SLOWEST,
     },
     "libsvtav1": {
         "0": Preset.SVTAV1_ULTRAFAST,
@@ -289,7 +300,7 @@ PRESET_MAPPING = {
         "10": Preset.SVTAV1_SLOWER,
         "11": Preset.SVTAV1_MUCHSLOWER,
         "12": Preset.SVTAV1_VERYSLOW,
-        "13": Preset.SVTAV1_SUPERSLOW
+        "13": Preset.SVTAV1_SUPERSLOW,
     },
     "librav1e": {
         "0": Preset.RAV1E_MUCHFASTER,
@@ -302,7 +313,7 @@ PRESET_MAPPING = {
         "7": Preset.RAV1E_SLOWER,
         "8": Preset.RAV1E_MUCHSLOWER,
         "9": Preset.RAV1E_VERYSLOW,
-        "10": Preset.RAV1E_SUPERSLOW
+        "10": Preset.RAV1E_SUPERSLOW,
     },
     "av1_nvenc": {
         "p1": Preset.AV1NV_FASTEST,
@@ -311,7 +322,7 @@ PRESET_MAPPING = {
         "p4": Preset.AV1NV_MEDIUM,
         "p5": Preset.AV1NV_SLOW,
         "p6": Preset.AV1NV_SLOWER,
-        "p7": Preset.AV1NV_SLOWEST
+        "p7": Preset.AV1NV_SLOWEST,
     },
     "av1_qsv": {
         "veryfast": Preset.AV1QSV_FASTEST,
@@ -320,8 +331,8 @@ PRESET_MAPPING = {
         "medium": Preset.AV1QSV_MEDIUM,
         "slow": Preset.AV1QSV_SLOW,
         "slower": Preset.AV1QSV_SLOWER,
-        "veryslow": Preset.AV1QSV_SLOWEST
-    }
+        "veryslow": Preset.AV1QSV_SLOWEST,
+    },
 }
 
 # Mapping of tune names to tune IDs for each codec
@@ -334,13 +345,13 @@ TUNE_MAPPING = {
         "zerolatency": Tune.X264_ZEROLATENCY,
         "animation": Tune.X264_ANIMATION,
         "film": Tune.X264_FILM,
-        "stillimage": Tune.X264_STILLIMAGE
+        "stillimage": Tune.X264_STILLIMAGE,
     },
     "h264_nvenc": {
         "hq": Tune.H264NV_HQ,
         "ll": Tune.H264NV_LL,
         "ull": Tune.H264NV_ULL,
-        "lossless": Tune.H264NV_LOSSLESS
+        "lossless": Tune.H264NV_LOSSLESS,
     },
     "libx265": {
         "psnr": Tune.X265_PSNR,
@@ -348,28 +359,25 @@ TUNE_MAPPING = {
         "grain": Tune.X265_GRAIN,
         "fastdecode": Tune.X265_FASTDECODE,
         "zerolatency": Tune.X265_ZEROLATENCY,
-        "animation": Tune.X265_ANIMATION
+        "animation": Tune.X265_ANIMATION,
     },
     "hevc_nvenc": {
         "hq": Tune.HEVCNV_HQ,
         "ll": Tune.HEVCNV_LL,
         "ull": Tune.HEVCNV_ULL,
-        "lossless": Tune.HEVCNV_LOSSLESS
+        "lossless": Tune.HEVCNV_LOSSLESS,
     },
     "libsvtav1": {
         "vq": Tune.SVTAV1_VQ,
         "psnr": Tune.SVTAV1_PSNR,
-        "fastdecode": Tune.SVTAV1_FASTDECODE
+        "fastdecode": Tune.SVTAV1_FASTDECODE,
     },
-    "librav1e": {
-        "psnr": Tune.RAV1E_PSNR,
-        "psychovisual": Tune.RAV1E_PSYCHOVISUAL
-    },
+    "librav1e": {"psnr": Tune.RAV1E_PSNR, "psychovisual": Tune.RAV1E_PSYCHOVISUAL},
     "av1_nvenc": {
         "hq": Tune.AV1NV_HQ,
         "ll": Tune.AV1NV_LL,
         "ull": Tune.AV1NV_ULL,
-        "lossless": Tune.AV1NV_LOSSLESS
+        "lossless": Tune.AV1NV_LOSSLESS,
     },
     "av1_qsv": {
         "unknown": Tune.AV1QSV_UNKNOWN,
@@ -380,8 +388,8 @@ TUNE_MAPPING = {
         "cameracapture": Tune.AV1QSV_CAMERACAPTURE,
         "videosurveillance": Tune.AV1QSV_VIDEOSURVEILLANCE,
         "gamestreaming": Tune.AV1QSV_GAMESTREAMING,
-        "remotegaming": Tune.AV1QSV_REMOTEGAMING
-    }
+        "remotegaming": Tune.AV1QSV_REMOTEGAMING,
+    },
 }
 
 # Default decoder mapping for encoders
@@ -396,7 +404,7 @@ DEFAULT_DECODER = {
     EncoderCodec.SVTAV1: DecoderCodec.DAV1D,
     EncoderCodec.RAV1E: DecoderCodec.DAV1D,
     EncoderCodec.AV1_NVENC: DecoderCodec.DAV1D,
-    EncoderCodec.AV1_QSV: DecoderCodec.DAV1D
+    EncoderCodec.AV1_QSV: DecoderCodec.DAV1D,
 }
 
 # Default decoder mapping for GPU-based encoders
@@ -404,14 +412,15 @@ DEFAULT_GPU_DECODER = {
     EncoderCodec.H264_NVENC: DecoderCodec.H264_CUVID,
     EncoderCodec.HEVC_NVENC: DecoderCodec.HEVC_CUVID,
     EncoderCodec.AV1_NVENC: DecoderCodec.AV1_CUVID,
-    EncoderCodec.AV1_QSV: DecoderCodec.AV1_QSV
+    EncoderCodec.AV1_QSV: DecoderCodec.AV1_QSV,
 }
+
 
 # Hardware detection functions
 def has_nvidia_gpu():
     """
     Detect if NVIDIA GPU is available for hardware acceleration.
-    
+
     Returns:
     --------
     bool
@@ -420,20 +429,18 @@ def has_nvidia_gpu():
     try:
         # Try to run nvidia-smi
         result = subprocess.run(
-            ["nvidia-smi"], 
-            stdout=subprocess.PIPE, 
-            stderr=subprocess.PIPE, 
-            timeout=2
+            ["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=2
         )
         return result.returncode == 0
     except (subprocess.SubprocessError, FileNotFoundError):
         # Command failed or not found
         return False
 
+
 def has_intel_gpu():
     """
     Detect if Intel GPU with QuickSync support is available.
-    
+
     Returns:
     --------
     bool
@@ -441,21 +448,18 @@ def has_intel_gpu():
     """
     try:
         # Try to run vainfo (Linux) or check Intel GPU in Windows
-        if os.name == 'posix':
+        if os.name == "posix":
             result = subprocess.run(
-                ["vainfo"], 
-                stdout=subprocess.PIPE, 
-                stderr=subprocess.PIPE, 
-                timeout=2
+                ["vainfo"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=2
             )
             return result.returncode == 0 and b"VA-API version" in result.stdout
-        elif os.name == 'nt':
+        elif os.name == "nt":
             # On Windows, check for Intel GPU in device manager (simplified)
             result = subprocess.run(
-                ["wmic", "path", "win32_VideoController", "get", "name"], 
-                stdout=subprocess.PIPE, 
-                stderr=subprocess.PIPE, 
-                timeout=2
+                ["wmic", "path", "win32_VideoController", "get", "name"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=2,
             )
             return result.returncode == 0 and b"Intel" in result.stdout
         else:
@@ -464,20 +468,35 @@ def has_intel_gpu():
         # Command failed or not found
         return False
 
+
 class FFMPEG(h5py.filters.FilterRefBase):
     """
     FFMPEG HDF5 filter class for h5py
-    
+
     This class implements the FFMPEG HDF5 filter interface for h5py,
     allowing compression of HDF5 datasets using video codecs.
     """
+
     filter_name = "ffmpeg"
     filter_id = FFMPEG_ID
 
-    def __init__(self, enc_id, dec_id, depth, height, width, bit_mode, preset, tune, crf, film_grain, gpu_id):
+    def __init__(
+        self,
+        enc_id,
+        dec_id,
+        depth,
+        height,
+        width,
+        bit_mode,
+        preset,
+        tune,
+        crf,
+        film_grain,
+        gpu_id,
+    ):
         """
         Create an FFMPEG filter instance with the given parameters.
-        
+
         Parameters:
         -----------
         enc_id : int
@@ -504,15 +523,37 @@ class FFMPEG(h5py.filters.FilterRefBase):
             GPU ID for hardware acceleration
         """
         self.filter_options = (
-            int(enc_id), int(dec_id), int(width), int(height), int(depth), 
-            int(bit_mode), int(preset), int(tune), int(crf), int(film_grain), int(gpu_id)
+            int(enc_id),
+            int(dec_id),
+            int(width),
+            int(height),
+            int(depth),
+            int(bit_mode),
+            int(preset),
+            int(tune),
+            int(crf),
+            int(film_grain),
+            int(gpu_id),
         )
 
-def ffmpeg(codec="libx264", decoder=None, preset=None, tune=None, crf=None, 
-           bit_mode=BitMode.BIT_8, film_grain=0, gpu_id=0, width=None, height=None, depth=None, **kwargs):
+
+def ffmpeg(
+    codec="libx264",
+    decoder=None,
+    preset=None,
+    tune=None,
+    crf=None,
+    bit_mode=BitMode.BIT_8,
+    film_grain=0,
+    gpu_id=0,
+    width=None,
+    height=None,
+    depth=None,
+    **kwargs,
+):
     """
     Create HDF5 filter parameters for FFMPEG compression.
-    
+
     Parameters:
     -----------
     codec : str
@@ -539,19 +580,21 @@ def ffmpeg(codec="libx264", decoder=None, preset=None, tune=None, crf=None,
         Custom depth override (default: auto-detected from data)
     **kwargs : dict
         Additional parameters (reserved for future use)
-    
+
     Returns:
     --------
     dict
         Filter parameters for h5py.create_dataset
     """
-    
+
     # Get encoder ID for the codec
     if codec not in CODEC_TO_ENCODER:
-        raise ValueError(f"Unknown codec: {codec}. Available codecs: {', '.join(CODEC_TO_ENCODER.keys())}")
-    
+        raise ValueError(
+            f"Unknown codec: {codec}. Available codecs: {', '.join(CODEC_TO_ENCODER.keys())}"
+        )
+
     enc_id = CODEC_TO_ENCODER[codec]
-    
+
     # Select decoder
     if decoder is None:
         # Use GPU decoder if using GPU encoder and no specific decoder is requested
@@ -562,9 +605,11 @@ def ffmpeg(codec="libx264", decoder=None, preset=None, tune=None, crf=None,
             dec_id = DEFAULT_DECODER[enc_id]
     else:
         if decoder not in CODEC_TO_DECODER:
-            raise ValueError(f"Unknown decoder: {decoder}. Available decoders: {', '.join(CODEC_TO_DECODER.keys())}")
+            raise ValueError(
+                f"Unknown decoder: {decoder}. Available decoders: {', '.join(CODEC_TO_DECODER.keys())}"
+            )
         dec_id = CODEC_TO_DECODER[decoder]
-    
+
     # Get preset ID
     preset_id = Preset.NONE
     if preset is not None:
@@ -572,8 +617,10 @@ def ffmpeg(codec="libx264", decoder=None, preset=None, tune=None, crf=None,
             preset_id = PRESET_MAPPING[codec][preset]
         else:
             valid_presets = list(PRESET_MAPPING.get(codec, {}).keys())
-            raise ValueError(f"Invalid preset '{preset}' for codec '{codec}'. Valid presets: {', '.join(valid_presets)}")
-    
+            raise ValueError(
+                f"Invalid preset '{preset}' for codec '{codec}'. Valid presets: {', '.join(valid_presets)}"
+            )
+
     # Get tune ID
     tune_id = Tune.NONE
     if tune is not None:
@@ -581,27 +628,40 @@ def ffmpeg(codec="libx264", decoder=None, preset=None, tune=None, crf=None,
             tune_id = TUNE_MAPPING[codec][tune]
         else:
             valid_tunes = list(TUNE_MAPPING.get(codec, {}).keys())
-            raise ValueError(f"Invalid tune '{tune}' for codec '{codec}'. Valid tunes: {', '.join(valid_tunes)}")
-    
+            raise ValueError(
+                f"Invalid tune '{tune}' for codec '{codec}'. Valid tunes: {', '.join(valid_tunes)}"
+            )
+
     # Check for hardware acceleration conflicts
     if gpu_id >= 0:
         # For NVIDIA encoders, check if NVIDIA GPU is available
         if "nvenc" in codec and not has_nvidia_gpu():
             raise RuntimeError(f"{codec} requested but NVIDIA GPU not detected.")
-        
+
         # For Intel QSV encoders, check if Intel GPU is available
         if "qsv" in codec and not has_intel_gpu():
             raise RuntimeError(f"{codec} requested but Intel GPU not detected.")
-    
+
     # Pack all parameters into the filter options
-    filter_options = (enc_id, dec_id, width or 0, height or 0, depth or 0, 
-                     bit_mode, preset_id, tune_id, crf or 0, film_grain, gpu_id)
-    
+    filter_options = (
+        enc_id,
+        dec_id,
+        width or 0,
+        height or 0,
+        depth or 0,
+        bit_mode,
+        preset_id,
+        tune_id,
+        crf or 0,
+        film_grain,
+        gpu_id,
+    )
+
     return {
-        'compression': FFMPEG_ID,
-        'compression_opts': filter_options,
-        'norm': kwargs.pop('norm', True),
-        'beta': kwargs.pop('beta', 1.0)
+        "compression": FFMPEG_ID,
+        "compression_opts": filter_options,
+        "norm": kwargs.pop("norm", True),
+        "beta": kwargs.pop("beta", 1.0),
     }
 
 
@@ -610,169 +670,238 @@ def mpeg4(crf=3, **kwargs):
     """Convenience function for H.264 compression"""
     return ffmpeg(codec="libxvid", crf=crf, **kwargs)
 
+
 def x264(preset="medium", crf=23, tune=None, **kwargs):
     """Convenience function for H.264 compression"""
     return ffmpeg(codec="libx264", preset=preset, crf=crf, tune=tune, **kwargs)
+
 
 def x265(preset="medium", crf=28, tune=None, **kwargs):
     """Convenience function for H.265/HEVC compression"""
     return ffmpeg(codec="libx265", preset=preset, crf=crf, tune=tune, **kwargs)
 
+
 def rav1e(preset="6", crf=30, tune=None, **kwargs):
     """Convenience function for AV1 compression"""
     return ffmpeg(codec="librav1e", preset=preset, crf=crf, tune=tune, **kwargs)
 
+
 def svtav1(preset="6", crf=30, tune="fastdecode", **kwargs):
     """Convenience function for AV1 compression"""
     return ffmpeg(codec="libsvtav1", preset=preset, crf=crf, tune=tune, **kwargs)
+
 
 def h264_nvenc(preset="p4", crf=23, **kwargs):
     """Convenience function for NVIDIA H.264 hardware compression"""
     gpu_id = kwargs.pop("gpu_id", 0)  # Default to first GPU
     return ffmpeg(codec="h264_nvenc", preset=preset, crf=crf, gpu_id=gpu_id, **kwargs)
 
+
 def hevc_nvenc(preset="p4", crf=23, **kwargs):
     """Convenience function for NVIDIA H.265/HEVC hardware compression"""
     gpu_id = kwargs.pop("gpu_id", 0)  # Default to first GPU
     return ffmpeg(codec="hevc_nvenc", preset=preset, crf=crf, gpu_id=gpu_id, **kwargs)
+
 
 def av1_nvenc(preset="p4", crf=23, **kwargs):
     """Convenience function for NVIDIA H.265/HEVC hardware compression"""
     gpu_id = kwargs.pop("gpu_id", 0)  # Default to first GPU
     return ffmpeg(codec="av1_nvenc", preset=preset, crf=crf, gpu_id=gpu_id, **kwargs)
 
+
 def av1_qsv(preset="medium", crf=30, tune=None, **kwargs):
     """Convenience function for Intel AV1 QSV hardware compression"""
     return ffmpeg(codec="av1_qsv", preset=preset, crf=crf, tune=tune, **kwargs)
 
+
 # native functions
 try:
     from ._ffmpeg_filter import ffmpeg_native_c
-    
+
     def read_metadata_from_compressed(compressed_data):
         """Extract metadata from compressed data header"""
         import struct
-        
+
         if len(compressed_data) < 8:
             raise ValueError("Invalid compressed data: too short")
-        
+
         offset = 0
-        
+
         # Read header: metadata size + version
-        metadata_size, version = struct.unpack('II', compressed_data[offset:offset+8])
+        metadata_size, version = struct.unpack(
+            "II", compressed_data[offset : offset + 8]
+        )
         offset += 8
-        
+
         if len(compressed_data) < 8 + metadata_size:
             raise ValueError("Invalid compressed data: metadata size mismatch")
-        
+
         if version == 1:
             # Read metadata fields (11 unsigned ints + 1 size_t)
-            metadata_values = struct.unpack('I' * 11, compressed_data[offset:offset+44])
+            metadata_values = struct.unpack(
+                "I" * 11, compressed_data[offset : offset + 44]
+            )
             offset += 44
-            
+
             # Read compressed_size as size_t
             import sys
+
             if sys.maxsize > 2**32:  # 64-bit system
-                compressed_size = struct.unpack('Q', compressed_data[offset:offset+8])[0]
+                compressed_size = struct.unpack(
+                    "Q", compressed_data[offset : offset + 8]
+                )[0]
                 offset += 8
             else:  # 32-bit system
-                compressed_size = struct.unpack('I', compressed_data[offset:offset+4])[0]
+                compressed_size = struct.unpack(
+                    "I", compressed_data[offset : offset + 4]
+                )[0]
                 offset += 4
-                
+
         elif version == 0:
             # Version 0 (legacy): all fields as unsigned int
-            metadata_values = struct.unpack('I' * 12, compressed_data[offset:offset+48])
+            metadata_values = struct.unpack(
+                "I" * 12, compressed_data[offset : offset + 48]
+            )
             compressed_size = metadata_values[11]
             metadata_values = metadata_values[:11]
             offset += 48
         else:
             raise ValueError(f"Unsupported metadata version: {version}")
-        
-        enc_id, dec_id, width, height, depth, bit_mode, preset_id, tune_id, crf, film_grain, gpu_id = metadata_values
-        
+
+        (
+            enc_id,
+            dec_id,
+            width,
+            height,
+            depth,
+            bit_mode,
+            preset_id,
+            tune_id,
+            crf,
+            film_grain,
+            gpu_id,
+        ) = metadata_values
+
         return {
-            'enc_id': enc_id,
-            'dec_id': dec_id,
-            'preset_id': preset_id,
-            'tune_id': tune_id,
-            'width': width,
-            'height': height,
-            'depth': depth,
-            'bit_mode': bit_mode,
-            'crf': crf,
-            'film_grain': film_grain,
-            'gpu_id': gpu_id,
-            'compressed_size': compressed_size,
-            'data_offset': offset,
-            'version': version
+            "enc_id": enc_id,
+            "dec_id": dec_id,
+            "preset_id": preset_id,
+            "tune_id": tune_id,
+            "width": width,
+            "height": height,
+            "depth": depth,
+            "bit_mode": bit_mode,
+            "crf": crf,
+            "film_grain": film_grain,
+            "gpu_id": gpu_id,
+            "compressed_size": compressed_size,
+            "data_offset": offset,
+            "version": version,
         }
-    
-    def ffmpeg_native(flags, data, codec="libx264", preset=None, tune=None, crf=23, 
-                     bit_mode=BitMode.BIT_8, film_grain=0, gpu_id=0):
+
+    def ffmpeg_native(
+        flags,
+        data,
+        codec="libx264",
+        preset=None,
+        tune=None,
+        crf=23,
+        bit_mode=BitMode.BIT_8,
+        film_grain=0,
+        gpu_id=0,
+    ):
         """Single native function for compress (flags=0) and decompress (flags=1)"""
-        
+
         if flags == 0:  # Compress
             enc_id = CODEC_TO_ENCODER[codec]
             dec_id = DEFAULT_DECODER[enc_id]
-            
-            preset_id = PRESET_MAPPING.get(codec, {}).get(preset, Preset.NONE) if preset else Preset.NONE
-            tune_id = TUNE_MAPPING.get(codec, {}).get(tune, Tune.NONE) if tune else Tune.NONE
 
-            data = np.ascontiguousarray(data, dtype=(np.uint8 if bit_mode == BitMode.BIT_8 else np.uint16))
-            
+            preset_id = (
+                PRESET_MAPPING.get(codec, {}).get(preset, Preset.NONE)
+                if preset
+                else Preset.NONE
+            )
+            tune_id = (
+                TUNE_MAPPING.get(codec, {}).get(tune, Tune.NONE) if tune else Tune.NONE
+            )
+
+            data = np.ascontiguousarray(
+                data, dtype=(np.uint8 if bit_mode == BitMode.BIT_8 else np.uint16)
+            )
+
             if data.ndim != 3:
                 raise ValueError("Data must be a 3D array (depth, height, width)")
 
             depth, height, width = data.shape
 
             buf_size = data.nbytes
-                
+
         else:  # Decompress (flags=1)
             # Read metadata from the compressed bytes
             metadata = read_metadata_from_compressed(data)
-            
+
             # Extract values from metadata
-            width = metadata['width']
-            height = metadata['height'] 
-            depth = metadata['depth']
-            bit_mode = metadata['bit_mode']
-            enc_id = metadata['enc_id']
-            dec_id = metadata['dec_id']
-            preset_id = metadata['preset_id']
-            tune_id = metadata['tune_id']
-            crf = metadata['crf']
-            film_grain = metadata['film_grain']
-            gpu_id = metadata['gpu_id']
-            
+            width = metadata["width"]
+            height = metadata["height"]
+            depth = metadata["depth"]
+            bit_mode = metadata["bit_mode"]
+            enc_id = metadata["enc_id"]
+            dec_id = metadata["dec_id"]
+            preset_id = metadata["preset_id"]
+            tune_id = metadata["tune_id"]
+            crf = metadata["crf"]
+            film_grain = metadata["film_grain"]
+            gpu_id = metadata["gpu_id"]
+
             # Extract only the compressed data (skip metadata)
-            data_offset = metadata['data_offset']
+            data_offset = metadata["data_offset"]
             data = data[data_offset:]
             buf_size = len(data)
-        
+
         # Build cd_values tuple (exactly 11 elements as expected by C function)
-        cd_values = (enc_id, dec_id, width, height, depth, bit_mode, 
-                    preset_id, tune_id, crf, film_grain, gpu_id)
-        
+        cd_values = (
+            enc_id,
+            dec_id,
+            width,
+            height,
+            depth,
+            bit_mode,
+            preset_id,
+            tune_id,
+            crf,
+            film_grain,
+            gpu_id,
+        )
+
         # Call C function
         return ffmpeg_native_c(flags, cd_values, buf_size, data)
-    
+
     # Convenience functions
     def compress_native(data, **kwargs):
         """Compress data using native FFMPEG"""
         return ffmpeg_native(0, data, **kwargs)
-    
+
     def decompress_native(compressed_data, **kwargs):
         """Decompress data using native FFMPEG"""
         return ffmpeg_native(1, compressed_data, **kwargs)
-        
+
     NATIVE_AVAILABLE = True
-        
+
 except ImportError:
+
     def ffmpeg_native(*args, **kwargs):
-        raise RuntimeError("Native functions not available - C extension not compiled with native support")
+        raise RuntimeError(
+            "Native functions not available - C extension not compiled with native support"
+        )
+
     def compress_native(*args, **kwargs):
-        raise RuntimeError("Native functions not available - C extension not compiled with native support")
+        raise RuntimeError(
+            "Native functions not available - C extension not compiled with native support"
+        )
+
     def decompress_native(*args, **kwargs):
-        raise RuntimeError("Native functions not available - C extension not compiled with native support")
-    
+        raise RuntimeError(
+            "Native functions not available - C extension not compiled with native support"
+        )
+
     NATIVE_AVAILABLE = False

--- a/h5ffmpeg/ffmpeg_filter.py
+++ b/h5ffmpeg/ffmpeg_filter.py
@@ -712,23 +712,19 @@ try:
         """Single native function for compress (flags=0) and decompress (flags=1)"""
         
         if flags == 0:  # Compress
-            data = np.asarray(data)
-            if data.ndim != 3:
-                raise ValueError("Data must be 3D (depth, height, width)")
-            
-            depth, height, width = data.shape
             enc_id = CODEC_TO_ENCODER[codec]
             dec_id = DEFAULT_DECODER[enc_id]
             
             preset_id = PRESET_MAPPING.get(codec, {}).get(preset, Preset.NONE) if preset else Preset.NONE
             tune_id = TUNE_MAPPING.get(codec, {}).get(tune, Tune.NONE) if tune else Tune.NONE
+
+            data = np.ascontiguousarray(data, dtype=(np.uint8 if bit_mode == BitMode.BIT_8 else np.uint16))
             
-            # Ensure correct data type
-            if bit_mode == BitMode.BIT_8:
-                data = np.ascontiguousarray(data, dtype=np.uint8)
-            else:
-                data = np.ascontiguousarray(data, dtype=np.uint16)
-            
+            if data.ndim != 3:
+                raise ValueError("Data must be a 3D array (depth, height, width)")
+
+            depth, height, width = data.shape
+
             buf_size = data.nbytes
                 
         else:  # Decompress (flags=1)

--- a/h5ffmpeg/ffmpeg_filter.py
+++ b/h5ffmpeg/ffmpeg_filter.py
@@ -9,10 +9,7 @@ import os
 import subprocess
 import numpy as np
 import h5py
-import functools
-import io
 import sys
-import contextlib
 import logging
 
 logger = logging.getLogger(__name__)

--- a/h5ffmpeg/ffmpeg_filter.py
+++ b/h5ffmpeg/ffmpeg_filter.py
@@ -744,8 +744,6 @@ try:
             offset += 44
 
             # Read compressed_size as size_t
-            import sys
-
             if sys.maxsize > 2**32:  # 64-bit system
                 compressed_size = struct.unpack(
                     "Q", compressed_data[offset : offset + 8]

--- a/h5ffmpeg/patches.py
+++ b/h5ffmpeg/patches.py
@@ -10,27 +10,28 @@ MAX_CHUNK_SIZE = 4 * 1024**3  # 4 GB
 _original_dataset_getitem = h5py.Dataset.__getitem__
 _original_dataset_setitem = h5py.Dataset.__setitem__
 
+
 # Define new getitem method
 def _patched_getitem(self, key):
     data = _original_dataset_getitem(self, key)
 
     # Check if this dataset should be quantized
-    if 'bit' not in self.attrs:
+    if "bit" not in self.attrs:
         return data
-    
-    norm = self.attrs.get('norm', False)
-    beta = self.attrs.get('beta', 1.0)
+
+    norm = self.attrs.get("norm", False)
+    beta = self.attrs.get("beta", 1.0)
     dtype_map = {0: np.uint8, 1: np.uint16, 2: np.float32}
-    dtype = dtype_map.get(self.attrs.get('data_type', 0), np.uint8)
-    
+    dtype = dtype_map.get(self.attrs.get("data_type", 0), np.uint8)
+
     if not norm and beta == 1.0:
         return data
-    
-    bit = self.attrs.get('bit', 8)
+
+    bit = self.attrs.get("bit", 8)
     max_bitType_val = (1 << bit) - 1
-    max_val = self.attrs.get('init_max_intensity', max_bitType_val)
-    min_val = self.attrs.get('init_min_intensity', 0)
-    
+    max_val = self.attrs.get("init_max_intensity", max_bitType_val)
+    min_val = self.attrs.get("init_min_intensity", 0)
+
     data = data.astype(np.float32, copy=False)
     if norm:
         if beta != 1.0 and beta > 0:
@@ -44,40 +45,41 @@ def _patched_getitem(self, key):
         np.clip(data + min_val, min_val, max_val, out=data)
     else:
         np.clip(data, min_val, max_val, out=data)
-            
+
     return data.astype(dtype, copy=False)
+
 
 # Define new setitem method
 def _patched_setitem(self, key, value):
     # Check if this dataset should be quantized
-    if 'bit' not in self.attrs:
+    if "bit" not in self.attrs:
         _original_dataset_setitem(self, key, value)
         return
-    
-    norm = self.attrs.get('norm', False)
-    beta = self.attrs.get('beta', 1.0)
-    
+
+    norm = self.attrs.get("norm", False)
+    beta = self.attrs.get("beta", 1.0)
+
     if not norm and beta == 1.0:
         _original_dataset_setitem(self, key, value)
         return
-    
+
     if value.dtype == np.float32:
         dtype = np.uint8
     else:
         dtype = value.dtype
-    
+
     data = np.asarray(value, dtype=np.float32)
-    bit = self.attrs.get('bit', 8)
+    bit = self.attrs.get("bit", 8)
     max_bitType_val = (1 << bit) - 1
-    
+
     # Fix: Safe handling of dtype for np.iinfo
     try:
         default_max = np.iinfo(dtype).max if dtype in [np.uint8, np.uint16] else 255
     except:
         default_max = 255
-    max_val = self.attrs.get('init_max_intensity', default_max)
-    min_val = self.attrs.get('init_min_intensity', 0)
-    
+    max_val = self.attrs.get("init_max_intensity", default_max)
+    min_val = self.attrs.get("init_min_intensity", 0)
+
     if norm:
         data -= min_val
         data /= max_val - min_val
@@ -90,8 +92,9 @@ def _patched_setitem(self, key, value):
         np.clip(data, 0, max_bitType_val, out=data)
     else:
         np.clip(data, 0, max_bitType_val, out=data)
-    
+
     _original_dataset_setitem(self, key, data.astype(dtype, copy=False))
+
 
 # Apply the patches
 h5py.Dataset.__getitem__ = _patched_getitem
@@ -100,14 +103,17 @@ h5py.Dataset.__setitem__ = _patched_setitem
 # Original create_dataset patching with modifications
 _original_group_create_dataset = h5py.Group.create_dataset
 
+
 def _patched_create_dataset(self, name, shape=None, dtype=None, data=None, **kwargs):
-    compression = kwargs.get('compression', 0)
+    compression = kwargs.get("compression", 0)
 
     if compression == FFMPEG_ID:
-        norm = kwargs.pop('norm', False)
-        beta = kwargs.pop('beta', 1.0)
-        compression_opts = list(kwargs.get('compression_opts', ()))
-        bit = {0: 8, 1: 10, 2: 12}.get(compression_opts[5] if len(compression_opts) > 5 else 0, 8)
+        norm = kwargs.pop("norm", False)
+        beta = kwargs.pop("beta", 1.0)
+        compression_opts = list(kwargs.get("compression_opts", ()))
+        bit = {0: 8, 1: 10, 2: 12}.get(
+            compression_opts[5] if len(compression_opts) > 5 else 0, 8
+        )
         use_quant = False
 
         if data is not None:
@@ -116,48 +122,61 @@ def _patched_create_dataset(self, name, shape=None, dtype=None, data=None, **kwa
             if not use_quant and len(compression_opts) > 5:
                 compression_opts[5] = 0
                 bit = 8
-            
-            kwargs['compression_opts'] = tuple(compression_opts)
+
+            kwargs["compression_opts"] = tuple(compression_opts)
 
         if dtype is not None:
             assert dtype in [np.uint8, np.uint16]
             use_quant = dtype != np.uint8
 
-        user_chunks = kwargs.get('chunks', None)
-        
+        user_chunks = kwargs.get("chunks", None)
+
         if user_chunks is None or user_chunks is True:
             final_shape = shape or (np.shape(data) if data is not None else None)
             if final_shape is None:
-                raise RuntimeError("Either 'data' or 'shape' must be provided for chunking.")
-                
-            final_dtype = np.dtype(dtype) if dtype is not None else (np.asarray(data).dtype if data is not None else np.uint8)
+                raise RuntimeError(
+                    "Either 'data' or 'shape' must be provided for chunking."
+                )
+
+            final_dtype = (
+                np.dtype(dtype)
+                if dtype is not None
+                else (np.asarray(data).dtype if data is not None else np.uint8)
+            )
             element_size = final_dtype.itemsize
             full_size = math.prod(final_shape) * element_size
-            
+
             if full_size <= MAX_CHUNK_SIZE:
                 chunks = final_shape
             else:
                 scale = (MAX_CHUNK_SIZE / full_size) ** (1 / len(final_shape))
-                chunks = tuple(max(1, min(dim, int(dim * scale))) for dim in final_shape)
-                
-            kwargs['chunks'] = chunks
-            
+                chunks = tuple(
+                    max(1, min(dim, int(dim * scale))) for dim in final_shape
+                )
+
+            kwargs["chunks"] = chunks
+
         elif isinstance(user_chunks, tuple):
             chunks = user_chunks
-            
+
         else:
-            raise ValueError(f"For FFMPEG compression, 'chunks' must be True, None, or a tuple, got {user_chunks}")
-        
-        comp_opts = list(kwargs.get('compression_opts', ()) if isinstance(kwargs.get('compression_opts', ()), Iterable) 
-                        else [kwargs.get('compression_opts', ())])
-                        
+            raise ValueError(
+                f"For FFMPEG compression, 'chunks' must be True, None, or a tuple, got {user_chunks}"
+            )
+
+        comp_opts = list(
+            kwargs.get("compression_opts", ())
+            if isinstance(kwargs.get("compression_opts", ()), Iterable)
+            else [kwargs.get("compression_opts", ())]
+        )
+
         comp_opts[2:5] = chunks[::-1]
-        kwargs['compression_opts'] = tuple(comp_opts)
-    
+        kwargs["compression_opts"] = tuple(comp_opts)
+
         # Process data for quantization
         init_max = None
         init_min = None
-        
+
         if use_quant and data is not None:
             data_dtype = data.dtype
             if data_dtype == np.uint16:
@@ -172,7 +191,7 @@ def _patched_create_dataset(self, name, shape=None, dtype=None, data=None, **kwa
                     beta = math.log(max_bit_val, init_max) - np.finfo(float).eps
                     data = np.power(data, beta)
 
-            elif data_dtype == np.float32: # MRI/CT has negative values
+            elif data_dtype == np.float32:  # MRI/CT has negative values
                 init_min, init_max = np.amin(data), np.amax(data)
                 max_bit_val = (1 << bit) - 1
 
@@ -180,7 +199,9 @@ def _patched_create_dataset(self, name, shape=None, dtype=None, data=None, **kwa
                     data = (data - init_min) / (init_max - init_min) * max_bit_val
                     data = np.power(data, beta)
                 else:
-                    beta = math.log(max_bit_val, init_max - init_min) - np.finfo(float).eps
+                    beta = (
+                        math.log(max_bit_val, init_max - init_min) - np.finfo(float).eps
+                    )
                     data = np.power(data - init_min, beta)
 
             if bit == 8:
@@ -192,24 +213,27 @@ def _patched_create_dataset(self, name, shape=None, dtype=None, data=None, **kwa
 
         # Create dataset and add attributes
         dset = _original_group_create_dataset(self, name, shape, dtype, data, **kwargs)
-        
+
         if use_quant:
             if norm:
-                dset.attrs['norm'] = norm
-            dset.attrs['bit'] = bit
+                dset.attrs["norm"] = norm
+            dset.attrs["bit"] = bit
             if beta != 1.0:
-                dset.attrs['beta'] = beta
-                
+                dset.attrs["beta"] = beta
+
             final_dtype = dtype or (data.dtype if data is not None else np.uint8)
             max_bit_val = (1 << bit) - 1
-            dset.attrs['init_max_intensity'] = init_max if init_max is not None else max_bit_val
-            dset.attrs['init_min_intensity'] = init_min if init_min is not None else 0
-            dtype_map = {'uint8': 0, 'uint16': 1, 'float32': 2}
-            dset.attrs['data_type'] = dtype_map.get(str(data_dtype), 0)
-        
+            dset.attrs["init_max_intensity"] = (
+                init_max if init_max is not None else max_bit_val
+            )
+            dset.attrs["init_min_intensity"] = init_min if init_min is not None else 0
+            dtype_map = {"uint8": 0, "uint16": 1, "float32": 2}
+            dset.attrs["data_type"] = dtype_map.get(str(data_dtype), 0)
+
         return dset
     else:
         return _original_group_create_dataset(self, name, shape, dtype, data, **kwargs)
+
 
 h5py.Group.create_dataset = _patched_create_dataset
 

--- a/h5ffmpeg/utils.py
+++ b/h5ffmpeg/utils.py
@@ -2,25 +2,27 @@ import os
 import tempfile
 import numpy as np
 import h5py
-import time 
+import time
+
 
 def create_temp_h5_file():
     """
     Create a temporary HDF5 file for testing.
-    
+
     Returns:
     --------
     str
         Path to the temporary file
     """
-    fd, path = tempfile.mkstemp(suffix='.h5')
+    fd, path = tempfile.mkstemp(suffix=".h5")
     os.close(fd)
     return path
+
 
 def cleanup_temp_file(file_path):
     """
     Clean up a temporary file.
-    
+
     Parameters:
     -----------
     file_path : str
@@ -29,17 +31,18 @@ def cleanup_temp_file(file_path):
     if os.path.exists(file_path):
         os.remove(file_path)
 
+
 def calculate_psnr(original, compressed):
     """
     Calculate Peak Signal-to-Noise Ratio between original and compressed data.
-    
+
     Parameters:
     -----------
     original : numpy.ndarray
         Original data
     compressed : numpy.ndarray
         Compressed and decompressed data
-        
+
     Returns:
     --------
     float
@@ -47,27 +50,28 @@ def calculate_psnr(original, compressed):
     """
     mse = np.mean((original - compressed) ** 2)
     if mse == 0:
-        return float('inf')
-    
+        return float("inf")
+
     if original.dtype == np.uint8:
         max_pixel = 255.0
     else:  # np.uint16
         max_pixel = 65535.0
-    
+
     psnr = 20 * np.log10(max_pixel / np.sqrt(mse))
     return psnr
+
 
 def calculate_compression_ratio(original_size, compressed_size):
     """
     Calculate compression ratio.
-    
+
     Parameters:
     -----------
     original_size : int
         Size of original data in bytes
     compressed_size : int
         Size of compressed data in bytes
-        
+
     Returns:
     --------
     float
@@ -75,15 +79,16 @@ def calculate_compression_ratio(original_size, compressed_size):
     """
     return original_size / compressed_size
 
+
 def get_file_size(file_path):
     """
     Get the size of a file in bytes.
-    
+
     Parameters:
     -----------
     file_path : str
         Path to the file
-        
+
     Returns:
     --------
     int
@@ -91,10 +96,11 @@ def get_file_size(file_path):
     """
     return os.path.getsize(file_path)
 
+
 def compress_and_decompress(data, compression_options, dataset_name="data"):
     """
     Compress and decompress data using the FFMPEG HDF5 filter.
-    
+
     Parameters:
     -----------
     data : numpy.ndarray
@@ -103,7 +109,7 @@ def compress_and_decompress(data, compression_options, dataset_name="data"):
         Compression options for h5py.create_dataset
     dataset_name : str
         Name of the dataset in the HDF5 file
-        
+
     Returns:
     --------
     tuple
@@ -112,23 +118,23 @@ def compress_and_decompress(data, compression_options, dataset_name="data"):
     assert data.ndim == 3, "Input needs to be 3D"
     # Create a temporary HDF5 file
     temp_file = create_temp_h5_file()
-    
+
     try:
         # Write data with compression
         start_time = time.time()
-        with h5py.File(temp_file, 'w') as f:\
+        with h5py.File(temp_file, "w") as f:
             f.create_dataset(dataset_name, data=data, **compression_options)
         enc_time = time.time() - start_time
-        
+
         # Get compressed file size
         compressed_size = get_file_size(temp_file)
-        
+
         # Read back the data
         start_time = time.time()
-        with h5py.File(temp_file, 'r') as f:
+        with h5py.File(temp_file, "r") as f:
             decompressed_data = f[dataset_name][:]
         dec_time = time.time() - start_time
-        
+
         # Calculate compression ratio
         original_size = data.nbytes
         compression_ratio = calculate_compression_ratio(original_size, compressed_size)
@@ -136,54 +142,57 @@ def compress_and_decompress(data, compression_options, dataset_name="data"):
         return decompressed_data, compression_ratio, compressed_size, enc_time, dec_time
     except Exception as e:
         print(str(e))
-    
+
     finally:
         # Clean up temporary file
         cleanup_temp_file(temp_file)
 
-def generate_3d_sample_vol(width=512, height=512, depth=100, dtype=np.uint8, pattern="stripes", seed=None):
+
+def generate_3d_sample_vol(
+    width=512, height=512, depth=100, dtype=np.uint8, pattern="stripes", seed=None
+):
     """
     Generate 3D volume test data.
     """
     if dtype not in [np.uint8, np.uint16]:
         raise ValueError("Only np.uint8 and np.uint16 data types are supported")
-    
+
     if seed is not None:
         np.random.seed(seed)
-    
+
     if pattern == "random":
         if dtype == np.uint8:
             return np.random.randint(0, 256, (depth, height, width), dtype=dtype)
         else:
             return np.random.randint(0, 65536, (depth, height, width), dtype=dtype)
-    
+
     elif pattern == "gradient":
         x = np.linspace(0, 1, width)
         y = np.linspace(0, 1, height)
         z = np.linspace(0, 1, depth)
-        xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
+        xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
         data = (xx + yy + zz) / 3
-        
+
         if dtype == np.uint8:
             data = (data * 255).astype(dtype)
         else:
             data = (data * 65535).astype(dtype)
-        
+
         return np.transpose(data, [2, 1, 0])
-    
+
     elif pattern == "stripes":
         x = np.arange(width)
         data = np.sin(x * 8 * np.pi / width)
         data = np.tile(data, (depth, height, 1))
-        
+
         data = (data + 1) / 2
-        
+
         if dtype == np.uint8:
             data = (data * 255).astype(dtype)
         else:
             data = (data * 65535).astype(dtype)
-        
-        return data  
-    
+
+        return data
+
     else:
         raise ValueError(f"Unknown pattern: {pattern}")

--- a/setup.py
+++ b/setup.py
@@ -7,116 +7,121 @@ import subprocess
 from setuptools import setup, Extension, find_packages
 from setuptools.command.build_ext import build_ext
 
+
 def is_building_sdist():
-    return 'sdist' in sys.argv or 'egg_info' in sys.argv
+    return "sdist" in sys.argv or "egg_info" in sys.argv
+
 
 def get_ffmpeg_root():
-    if 'FFMPEG_ROOT' in os.environ:
-        return os.environ['FFMPEG_ROOT']
-    
+    if "FFMPEG_ROOT" in os.environ:
+        return os.environ["FFMPEG_ROOT"]
+
     system = platform.system().lower()
-    if system == 'windows':
-        home = os.environ.get('HOME', 'D:\\a')
-        return os.path.join(home, 'ffmpeg_build')
-    elif system == 'darwin':
-        home = os.path.expanduser('~')
-        return os.path.join(home, 'ffmpeg')
+    if system == "windows":
+        home = os.environ.get("HOME", "D:\\a")
+        return os.path.join(home, "ffmpeg_build")
+    elif system == "darwin":
+        home = os.path.expanduser("~")
+        return os.path.join(home, "ffmpeg")
     else:
-        return '/opt/ffmpeg'
+        return "/opt/ffmpeg"
+
 
 def get_hdf5_root():
-    if 'HDF5_ROOT' in os.environ:
-        return os.environ['HDF5_ROOT']
-    
+    if "HDF5_ROOT" in os.environ:
+        return os.environ["HDF5_ROOT"]
+
     system = platform.system().lower()
-    if system == 'windows':
-        home = os.environ.get('HOME', 'D:\\a')
-        hdf5_dir = os.path.join(home, 'ffmpeg_build')
-        
-        if os.path.exists(os.path.join(hdf5_dir, 'include', 'hdf5.h')):
+    if system == "windows":
+        home = os.environ.get("HOME", "D:\\a")
+        hdf5_dir = os.path.join(home, "ffmpeg_build")
+
+        if os.path.exists(os.path.join(hdf5_dir, "include", "hdf5.h")):
             return hdf5_dir
-    elif system == 'darwin':
+    elif system == "darwin":
         possible_paths = [
-            '/opt/homebrew/opt/hdf5',
-            '/usr/local/opt/hdf5', 
-            os.path.expanduser('~/miniconda3/lib'),
+            "/opt/homebrew/opt/hdf5",
+            "/usr/local/opt/hdf5",
+            os.path.expanduser("~/miniconda3/lib"),
         ]
         for path in possible_paths:
-            if os.path.exists(os.path.join(path, 'include', 'hdf5.h')):
+            if os.path.exists(os.path.join(path, "include", "hdf5.h")):
                 return path
     else:
         possible_paths = [
-            '/usr/include/hdf5',
-            '/usr/local/include/hdf5',
-            '/opt/conda/include',
+            "/usr/include/hdf5",
+            "/usr/local/include/hdf5",
+            "/opt/conda/include",
         ]
         for path in possible_paths:
-            if os.path.exists(os.path.join(path, 'hdf5.h')):
+            if os.path.exists(os.path.join(path, "hdf5.h")):
                 return os.path.dirname(path)
-    
+
     return None
+
 
 def check_hdf5_installation():
     """Check what HDF5 files are actually available"""
     if HDF5_ROOT:
-        lib_dir = os.path.join(HDF5_ROOT, 'lib')
-        bin_dir = os.path.join(HDF5_ROOT, 'bin')
-        
+        lib_dir = os.path.join(HDF5_ROOT, "lib")
+        bin_dir = os.path.join(HDF5_ROOT, "bin")
+
         print(f"\n=== HDF5 Installation Check ===")
         print(f"HDF5_ROOT: {HDF5_ROOT}")
-        
+
         if os.path.exists(lib_dir):
             print(f"\nLibrary files in {lib_dir}:")
-            lib_files = [f for f in os.listdir(lib_dir) if f.endswith('.lib')]
+            lib_files = [f for f in os.listdir(lib_dir) if f.endswith(".lib")]
             for lib_file in sorted(lib_files):
                 print(f"  {lib_file}")
         else:
             print(f"Library directory not found: {lib_dir}")
-            
+
         if os.path.exists(bin_dir):
             print(f"\nDLL files in {bin_dir}:")
-            dll_files = [f for f in os.listdir(bin_dir) if f.endswith('.dll')]
+            dll_files = [f for f in os.listdir(bin_dir) if f.endswith(".dll")]
             for dll_file in sorted(dll_files):
                 print(f"  {dll_file}")
         else:
             print(f"Binary directory not found: {bin_dir}")
-            
+
         print("=================================\n")
+
 
 if is_building_sdist():
     print("Building source distribution - skipping FFmpeg/HDF5 dependency checks")
-    
+
     ffmpeg_module = Extension(
-        'h5ffmpeg._ffmpeg_filter',
+        "h5ffmpeg._ffmpeg_filter",
         sources=[
-            os.path.join('h5ffmpeg', '_ffmpeg_filter.c'), 
-            os.path.join('src', 'ffmpeg_h5filter.c'),
-            os.path.join('src', 'ffmpeg_native.c'),
-            os.path.join('src', 'ffmpeg_utils.c'),
-            os.path.join('src', 'ffmpeg_h5plugin.c')
-        ]
+            os.path.join("h5ffmpeg", "_ffmpeg_filter.c"),
+            os.path.join("src", "ffmpeg_h5filter.c"),
+            os.path.join("src", "ffmpeg_native.c"),
+            os.path.join("src", "ffmpeg_utils.c"),
+            os.path.join("src", "ffmpeg_h5plugin.c"),
+        ],
     )
-    
+
     class CustomBuildExt(build_ext):
         pass
-        
+
 else:
     FFMPEG_ROOT = get_ffmpeg_root()
     HDF5_ROOT = get_hdf5_root()
 
-    src_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'src')
+    src_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
     print(f"Source directory: {src_dir}")
     print(f"FFMPEG_ROOT: {FFMPEG_ROOT}")
     print(f"HDF5_ROOT: {HDF5_ROOT}")
     print(f"Building for: {platform.system()} {platform.machine()}")
 
     required_files = [
-        os.path.join(src_dir, 'ffmpeg_h5filter.h'),
-        os.path.join(src_dir, 'ffmpeg_utils.h'),
-        os.path.join(src_dir, 'ffmpeg_h5filter.c'),
-        os.path.join(src_dir, 'ffmpeg_h5plugin.c'),
-        os.path.join(src_dir, 'ffmpeg_utils.c'),
-        os.path.join(src_dir, 'ffmpeg_native.c')
+        os.path.join(src_dir, "ffmpeg_h5filter.h"),
+        os.path.join(src_dir, "ffmpeg_utils.h"),
+        os.path.join(src_dir, "ffmpeg_h5filter.c"),
+        os.path.join(src_dir, "ffmpeg_h5plugin.c"),
+        os.path.join(src_dir, "ffmpeg_utils.c"),
+        os.path.join(src_dir, "ffmpeg_native.c"),
     ]
 
     for file_path in required_files:
@@ -128,194 +133,204 @@ else:
 
     if not os.path.exists(FFMPEG_ROOT):
         print(f"ERROR: FFmpeg directory not found: {FFMPEG_ROOT}")
-        print("Make sure FFMPEG_ROOT environment variable is set correctly or FFmpeg is built.")
+        print(
+            "Make sure FFMPEG_ROOT environment variable is set correctly or FFmpeg is built."
+        )
         sys.exit(1)
 
-    ffmpeg_include = os.path.join(FFMPEG_ROOT, 'include')
-    ffmpeg_lib = os.path.join(FFMPEG_ROOT, 'lib')
+    ffmpeg_include = os.path.join(FFMPEG_ROOT, "include")
+    ffmpeg_lib = os.path.join(FFMPEG_ROOT, "lib")
 
     if not os.path.exists(ffmpeg_include):
         print(f"ERROR: FFmpeg include directory not found: {ffmpeg_include}")
-        print(f"Contents of FFMPEG_ROOT: {os.listdir(FFMPEG_ROOT) if os.path.exists(FFMPEG_ROOT) else 'Directory does not exist'}")
+        print(
+            f"Contents of FFMPEG_ROOT: {os.listdir(FFMPEG_ROOT) if os.path.exists(FFMPEG_ROOT) else 'Directory does not exist'}"
+        )
         sys.exit(1)
 
     if not os.path.exists(ffmpeg_lib):
         print(f"ERROR: FFmpeg lib directory not found: {ffmpeg_lib}")
-        print(f"Contents of FFMPEG_ROOT: {os.listdir(FFMPEG_ROOT) if os.path.exists(FFMPEG_ROOT) else 'Directory does not exist'}")
+        print(
+            f"Contents of FFMPEG_ROOT: {os.listdir(FFMPEG_ROOT) if os.path.exists(FFMPEG_ROOT) else 'Directory does not exist'}"
+        )
         sys.exit(1)
 
     system = platform.system().lower()
     machine = platform.machine().lower()
 
-    include_dirs = [
-        src_dir,
-        ffmpeg_include
-    ]
+    include_dirs = [src_dir, ffmpeg_include]
 
-    library_dirs = [
-        ffmpeg_lib
-    ]
+    library_dirs = [ffmpeg_lib]
 
-    if system == 'windows':
-        shared_lib_ext = '.dll'
-        static_lib_ext = '.lib'
-        lib_prefix = ''
-        ffmpeg_bin = os.path.join(FFMPEG_ROOT, 'bin')
+    if system == "windows":
+        shared_lib_ext = ".dll"
+        static_lib_ext = ".lib"
+        lib_prefix = ""
+        ffmpeg_bin = os.path.join(FFMPEG_ROOT, "bin")
         if os.path.exists(ffmpeg_bin):
             library_dirs.append(ffmpeg_bin)
-    elif system == 'darwin':
-        shared_lib_ext = '.dylib'
-        static_lib_ext = '.a'
-        lib_prefix = 'lib'
+    elif system == "darwin":
+        shared_lib_ext = ".dylib"
+        static_lib_ext = ".a"
+        lib_prefix = "lib"
     else:
-        shared_lib_ext = '.so'
-        static_lib_ext = '.a'
-        lib_prefix = 'lib'
+        shared_lib_ext = ".so"
+        static_lib_ext = ".a"
+        lib_prefix = "lib"
 
-    def find_library(lib_name, search_dirs, prefix=lib_prefix, extensions=[shared_lib_ext, static_lib_ext]):
+    def find_library(
+        lib_name,
+        search_dirs,
+        prefix=lib_prefix,
+        extensions=[shared_lib_ext, static_lib_ext],
+    ):
         for dir_path in search_dirs:
             if not os.path.exists(dir_path):
                 continue
-                
+
             for ext in extensions:
                 lib_path = os.path.join(dir_path, f"{prefix}{lib_name}{ext}")
                 if os.path.exists(lib_path):
                     print(f"Found library: {lib_path}")
                     return dir_path
-                    
-            if system == 'windows':
-                dll_patterns = [
-                    f"{lib_name}*.dll",
-                    f"lib{lib_name}*.dll"
-                ]
-                
+
+            if system == "windows":
+                dll_patterns = [f"{lib_name}*.dll", f"lib{lib_name}*.dll"]
+
                 for pattern in dll_patterns:
                     dll_files = glob.glob(os.path.join(dir_path, pattern))
                     if dll_files:
                         print(f"Found Windows DLL: {dll_files[0]}")
                         return dir_path
-                        
+
         return None
 
     def configure_hdf5():
         if HDF5_ROOT:
-            hdf5_include_dir = os.path.join(HDF5_ROOT, 'include')
-            hdf5_library_dir = os.path.join(HDF5_ROOT, 'lib')
-            
+            hdf5_include_dir = os.path.join(HDF5_ROOT, "include")
+            hdf5_library_dir = os.path.join(HDF5_ROOT, "lib")
+
             if os.path.exists(hdf5_include_dir) and os.path.exists(hdf5_library_dir):
-                if os.path.exists(os.path.join(hdf5_include_dir, 'hdf5.h')):
+                if os.path.exists(os.path.join(hdf5_include_dir, "hdf5.h")):
                     include_dirs.append(hdf5_include_dir)
                     library_dirs.append(hdf5_library_dir)
-                    print(f"Using HDF5 from HDF5_ROOT: include={hdf5_include_dir}, lib={hdf5_library_dir}")
+                    print(
+                        f"Using HDF5 from HDF5_ROOT: include={hdf5_include_dir}, lib={hdf5_library_dir}"
+                    )
                     return True
                 else:
                     print(f"WARNING: hdf5.h not found in {hdf5_include_dir}")
             else:
-                print(f"WARNING: HDF5_ROOT directories don't exist: include={hdf5_include_dir}, lib={hdf5_library_dir}")
-        
+                print(
+                    f"WARNING: HDF5_ROOT directories don't exist: include={hdf5_include_dir}, lib={hdf5_library_dir}"
+                )
+
         try:
-            hdf5_cflags = subprocess.check_output(['pkg-config', '--cflags', 'hdf5'], 
-                                                universal_newlines=True, stderr=subprocess.DEVNULL).strip()
-            hdf5_libs = subprocess.check_output(['pkg-config', '--libs', 'hdf5'], 
-                                               universal_newlines=True, stderr=subprocess.DEVNULL).strip()
-            
+            hdf5_cflags = subprocess.check_output(
+                ["pkg-config", "--cflags", "hdf5"],
+                universal_newlines=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+            hdf5_libs = subprocess.check_output(
+                ["pkg-config", "--libs", "hdf5"],
+                universal_newlines=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+
             print(f"pkg-config HDF5 cflags: {hdf5_cflags}")
             print(f"pkg-config HDF5 libs: {hdf5_libs}")
-            
+
             hdf5_found = False
             for flag in hdf5_cflags.split():
-                if flag.startswith('-I'):
+                if flag.startswith("-I"):
                     include_dir = flag[2:]
-                    if os.path.exists(os.path.join(include_dir, 'hdf5.h')):
+                    if os.path.exists(os.path.join(include_dir, "hdf5.h")):
                         include_dirs.append(include_dir)
                         hdf5_found = True
                         print(f"Added HDF5 include dir from pkg-config: {include_dir}")
-            
+
             for flag in hdf5_libs.split():
-                if flag.startswith('-L'):
+                if flag.startswith("-L"):
                     lib_dir = flag[2:]
                     if os.path.exists(lib_dir):
                         library_dirs.append(lib_dir)
                         print(f"Added HDF5 library dir from pkg-config: {lib_dir}")
-            
+
             if hdf5_found:
                 print("Successfully configured HDF5 using pkg-config")
                 return True
-                        
+
         except (subprocess.CalledProcessError, FileNotFoundError):
             print("pkg-config not available or could not find HDF5")
-        
+
         potential_include_dirs = []
         potential_library_dirs = []
-        
-        if system == 'linux':
+
+        if system == "linux":
             potential_include_dirs = [
-                '/usr/include/hdf5/serial',
-                '/usr/include/hdf5',
-                '/usr/include',
-                '/usr/local/include'
+                "/usr/include/hdf5/serial",
+                "/usr/include/hdf5",
+                "/usr/include",
+                "/usr/local/include",
             ]
             potential_library_dirs = [
-                '/usr/lib/x86_64-linux-gnu/hdf5/serial',
-                '/usr/lib/x86_64-linux-gnu',
-                '/usr/lib64',
-                '/usr/lib',
-                '/usr/local/lib'
+                "/usr/lib/x86_64-linux-gnu/hdf5/serial",
+                "/usr/lib/x86_64-linux-gnu",
+                "/usr/lib64",
+                "/usr/lib",
+                "/usr/local/lib",
             ]
-        elif system == 'darwin':
+        elif system == "darwin":
             potential_include_dirs = [
-                '/opt/homebrew/include',
-                '/usr/local/include',
-                '/usr/local/opt/hdf5/include'
+                "/opt/homebrew/include",
+                "/usr/local/include",
+                "/usr/local/opt/hdf5/include",
             ]
             potential_library_dirs = [
-                '/opt/homebrew/lib',
-                '/usr/local/lib',
-                '/usr/local/opt/hdf5/lib'
+                "/opt/homebrew/lib",
+                "/usr/local/lib",
+                "/usr/local/opt/hdf5/lib",
             ]
-        elif system == 'windows':
+        elif system == "windows":
             potential_include_dirs = [
-                'C:\\Program Files\\HDF5\\include',
-                'C:\\HDF5\\include'
+                "C:\\Program Files\\HDF5\\include",
+                "C:\\HDF5\\include",
             ]
-            potential_library_dirs = [
-                'C:\\Program Files\\HDF5\\lib',
-                'C:\\HDF5\\lib'
-            ]
-        
+            potential_library_dirs = ["C:\\Program Files\\HDF5\\lib", "C:\\HDF5\\lib"]
+
         hdf5_include_found = False
         for dir_path in potential_include_dirs:
-            if os.path.exists(os.path.join(dir_path, 'hdf5.h')):
+            if os.path.exists(os.path.join(dir_path, "hdf5.h")):
                 include_dirs.append(dir_path)
                 hdf5_include_found = True
                 print(f"Found HDF5 header at: {os.path.join(dir_path, 'hdf5.h')}")
                 break
-        
+
         hdf5_lib_found = False
-        hdf5_library_dir = find_library('hdf5', potential_library_dirs)
+        hdf5_library_dir = find_library("hdf5", potential_library_dirs)
         if hdf5_library_dir:
             library_dirs.append(hdf5_library_dir)
             hdf5_lib_found = True
-        
+
         if not hdf5_include_found or not hdf5_lib_found:
             print("ERROR: Could not find HDF5 development libraries.")
             print("Please ensure HDF5 is installed:")
             print("  Linux: sudo apt-get install libhdf5-dev")
-            print("  macOS: brew install hdf5") 
+            print("  macOS: brew install hdf5")
             print("  Windows: Install HDF5 or set HDF5_ROOT environment variable")
             sys.exit(1)
-        
+
         return True
 
     configure_hdf5()
     check_hdf5_installation()
 
-    ffmpeg_libs = ['avcodec', 'avutil', 'avformat', 'swscale']
+    ffmpeg_libs = ["avcodec", "avutil", "avformat", "swscale"]
     missing_ffmpeg_libs = []
 
     print("Checking FFmpeg headers...")
     for lib in ffmpeg_libs:
-        header_path = os.path.join(FFMPEG_ROOT, 'include', f'lib{lib}', f'{lib}.h')
+        header_path = os.path.join(FFMPEG_ROOT, "include", f"lib{lib}", f"{lib}.h")
         if os.path.exists(header_path):
             print(f"Found FFmpeg header: {header_path}")
         else:
@@ -334,51 +349,56 @@ else:
         print("Continuing build - libraries may be found at runtime")
 
     # Base libraries for all platforms
-    libraries = ['avcodec', 'avutil', 'avformat', 'swscale']
-    
-    # Add HDF5 libraries - Windows needs multiple HDF5 libs
-    if system == 'windows':
-        libraries.extend([
-            'hdf5',           # Main HDF5 library
-            'hdf5_hl',        # High-level HDF5 APIs
-            'shlwapi'         # Windows system library
-        ])
-    else:
-        libraries.extend(['hdf5'])
+    libraries = ["avcodec", "avutil", "avformat", "swscale"]
 
-    extra_compile_args = ['-DFFMPEG_H5_FILTER_EXPORTS',
-                          '-DFFMPEG_NATIVE_SUPPORT']
+    # Add HDF5 libraries - Windows needs multiple HDF5 libs
+    if system == "windows":
+        libraries.extend(
+            [
+                "hdf5",  # Main HDF5 library
+                "hdf5_hl",  # High-level HDF5 APIs
+                "shlwapi",  # Windows system library
+            ]
+        )
+    else:
+        libraries.extend(["hdf5"])
+
+    extra_compile_args = ["-DFFMPEG_H5_FILTER_EXPORTS", "-DFFMPEG_NATIVE_SUPPORT"]
     extra_link_args = []
 
-    if system == 'linux':
-        extra_compile_args.extend(['-std=c99', '-fPIC', '-D_POSIX_C_SOURCE=200809L'])
-        extra_link_args.extend(['-Wl,--no-as-needed'])
+    if system == "linux":
+        extra_compile_args.extend(["-std=c99", "-fPIC", "-D_POSIX_C_SOURCE=200809L"])
+        extra_link_args.extend(["-Wl,--no-as-needed"])
         for dir_path in library_dirs:
-            extra_link_args.append(f'-Wl,-rpath,{dir_path}')
-    elif system == 'darwin':
-        extra_compile_args.extend(['-std=c99', '-fPIC'])
-        extra_link_args.extend([
-            '-Wl,-rpath,@loader_path',
-            '-Wl,-rpath,@loader_path/../../',
-        ])
+            extra_link_args.append(f"-Wl,-rpath,{dir_path}")
+    elif system == "darwin":
+        extra_compile_args.extend(["-std=c99", "-fPIC"])
+        extra_link_args.extend(
+            [
+                "-Wl,-rpath,@loader_path",
+                "-Wl,-rpath,@loader_path/../../",
+            ]
+        )
         for dir_path in library_dirs:
-            extra_link_args.append(f'-Wl,-rpath,{dir_path}')
-    elif system == 'windows':
-        extra_compile_args.extend([
-            '/std:c11',
-            '-D_CRT_SECURE_NO_WARNINGS',
-            '-DH5_BUILT_AS_DYNAMIC_LIB',
-            '-D_HDF5USEDLL_'
-        ])
+            extra_link_args.append(f"-Wl,-rpath,{dir_path}")
+    elif system == "windows":
+        extra_compile_args.extend(
+            [
+                "/std:c11",
+                "-D_CRT_SECURE_NO_WARNINGS",
+                "-DH5_BUILT_AS_DYNAMIC_LIB",
+                "-D_HDF5USEDLL_",
+            ]
+        )
 
     ffmpeg_module = Extension(
-        'h5ffmpeg._ffmpeg_filter',
+        "h5ffmpeg._ffmpeg_filter",
         sources=[
-            os.path.join('h5ffmpeg', '_ffmpeg_filter.c'), 
-            os.path.join('src', 'ffmpeg_h5filter.c'),
-            os.path.join('src', 'ffmpeg_h5plugin.c'),
-            os.path.join('src', 'ffmpeg_native.c'),
-            os.path.join('src', 'ffmpeg_utils.c')
+            os.path.join("h5ffmpeg", "_ffmpeg_filter.c"),
+            os.path.join("src", "ffmpeg_h5filter.c"),
+            os.path.join("src", "ffmpeg_h5plugin.c"),
+            os.path.join("src", "ffmpeg_native.c"),
+            os.path.join("src", "ffmpeg_utils.c"),
         ],
         include_dirs=include_dirs,
         library_dirs=library_dirs,
@@ -391,11 +411,13 @@ else:
         def finalize_options(self):
             build_ext.finalize_options(self)
             import builtins
+
             builtins.__NUMPY_SETUP__ = False
             import numpy
+
             self.include_dirs.append(numpy.get_include())
             print(f"Added numpy include directory: {numpy.get_include()}")
-            
+
         def build_extension(self, ext):
             print(f"\n{'='*50}")
             print(f"Building extension: {ext.name}")
@@ -407,21 +429,24 @@ else:
             print(f"Extra compile args: {ext.extra_compile_args}")
             print(f"Extra link args: {ext.extra_link_args}")
             print(f"{'='*50}\n")
-            
+
             super().build_extension(ext)
-            
-            output_dir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+
+            output_dir = os.path.abspath(
+                os.path.dirname(self.get_ext_fullpath(ext.name))
+            )
             print(f"Extension built and saved to: {output_dir}")
-            
+
             system = platform.system().lower()
-            if system != 'windows':
+            if system != "windows":
                 lib_file = self.get_ext_fullpath(ext.name)
                 if os.path.exists(lib_file):
                     os.chmod(lib_file, 0o755)
                     print(f"Set executable permission on {lib_file}")
 
+
 try:
-    with open('README.md', 'r', encoding='utf-8') as f:
+    with open("README.md", "r", encoding="utf-8") as f:
         long_description = f.read()
 except FileNotFoundError:
     long_description = "HDF5 filter plugin for FFMPEG video codec compression"
@@ -447,17 +472,17 @@ setup(
         "scikit-image>=0.25.2",
     ],
     extras_require={
-        'nvidia': ['cupy-cuda11x'],
-        'intel': ['intel-openmp'],
+        "nvidia": ["cupy-cuda11x"],
+        "intel": ["intel-openmp"],
     },
     python_requires=">=3.11",
-    cmdclass={'build_ext': CustomBuildExt},
+    cmdclass={"build_ext": CustomBuildExt},
     license="MIT",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.11", 
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering",
@@ -466,7 +491,7 @@ setup(
         "Topic :: Multimedia :: Video :: Conversion",
     ],
     package_data={
-        'h5ffmpeg': ['*.so', '*.dll', '*.dylib', '*.pyd'],
+        "h5ffmpeg": ["*.so", "*.dll", "*.dylib", "*.pyd"],
     },
     include_package_data=True,
     zip_safe=False,

--- a/tests/colored_test.py
+++ b/tests/colored_test.py
@@ -2,44 +2,56 @@ import unittest
 from colorama import Fore, Back, Style
 from tabulate import tabulate
 
+
 class ColoredTestResult(unittest.TextTestResult):
     """Custom test result class that colorizes the output."""
-    
+
     def addSuccess(self, test):
         super().addSuccess(test)
-        self.stream.writeln(f"{Fore.GREEN}✓ {test.shortDescription() or str(test)}{Style.RESET_ALL}")
-    
+        self.stream.writeln(
+            f"{Fore.GREEN}✓ {test.shortDescription() or str(test)}{Style.RESET_ALL}"
+        )
+
     def addError(self, test, err):
         super().addError(test, err)
-        self.stream.writeln(f"{Fore.RED}✗ ERROR: {test.shortDescription() or str(test)}{Style.RESET_ALL}")
-        
+        self.stream.writeln(
+            f"{Fore.RED}✗ ERROR: {test.shortDescription() or str(test)}{Style.RESET_ALL}"
+        )
+
     def addFailure(self, test, err):
         super().addFailure(test, err)
-        self.stream.writeln(f"{Fore.RED}✗ FAIL: {test.shortDescription() or str(test)}{Style.RESET_ALL}")
-        
+        self.stream.writeln(
+            f"{Fore.RED}✗ FAIL: {test.shortDescription() or str(test)}{Style.RESET_ALL}"
+        )
+
     def addSkip(self, test, reason):
         super().addSkip(test, reason)
-        self.stream.writeln(f"{Fore.YELLOW}⚠ SKIP: {test.shortDescription() or str(test)} ({reason}){Style.RESET_ALL}")
+        self.stream.writeln(
+            f"{Fore.YELLOW}⚠ SKIP: {test.shortDescription() or str(test)} ({reason}){Style.RESET_ALL}"
+        )
+
 
 class ColoredTestRunner(unittest.TextTestRunner):
     """Custom test runner that uses the ColoredTestResult class."""
+
     resultclass = ColoredTestResult
+
 
 def print_summary(name, result):
     """Print a colorized summary of test results."""
     print(f"\n{Back.CYAN}{Fore.BLACK}{Style.BRIGHT} {name} SUMMARY {Style.RESET_ALL}")
     print(f"{Fore.CYAN}{'═' * 60}{Style.RESET_ALL}")
-    
+
     # Count results
     total = result.testsRun
     failed = len(result.failures)
     errors = len(result.errors)
     skipped = len(result.skipped)
     passed = total - failed - errors - skipped
-    
+
     # Calculate percentages
     pass_percent = (passed / total) * 100 if total > 0 else 0
-    
+
     # Determine overall status color
     if failed > 0 or errors > 0:
         status_color = Fore.RED
@@ -47,7 +59,7 @@ def print_summary(name, result):
     else:
         status_color = Fore.GREEN
         status_text = "PASSED"
-    
+
     # Print counts with colors
     print(f"Total tests: {total}")
     print(f"  {Fore.GREEN}✓ Passed: {passed} ({pass_percent:.1f}%){Style.RESET_ALL}")
@@ -57,7 +69,7 @@ def print_summary(name, result):
         print(f"  {Fore.RED}✗ Errors: {errors}{Style.RESET_ALL}")
     if skipped > 0:
         print(f"  {Fore.YELLOW}⚠ Skipped: {skipped}{Style.RESET_ALL}")
-    
+
     # Print overall status
     print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}")
     print(f"Overall status: {status_color}{Style.BRIGHT}{status_text}{Style.RESET_ALL}")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -22,47 +22,45 @@ colorama.init(autoreset=True)
 # Import test utilities
 from test_utils import generate_3d_data
 
-from colored_test import (
-    ColoredTestRunner,
-    print_summary
-    )
+from colored_test import ColoredTestRunner, print_summary
+
 
 class TestBasicFunctionality(unittest.TestCase):
     """
     Test basic functionality of the FFMPEG HDF5 filter.
     """
-    
+
     def setUp(self):
         """Set up test parameters."""
         # Define dimensions for the test data
         self.width = 256
         self.height = 256
         self.depth = 50
-        
+
         # Set random seed for reproducibility
         self.seed = 42
-        
+
         # Minimum acceptable PSNR values
         self.min_psnr_8bit = 25.0  # dB
         self.min_psnr_16bit = 45.0  # dB
-        
+
         # Minimum acceptable compression ratio
         self.min_compression_ratio = 1.5
-        
+
         # Print test header
         test_name = self._testMethodName
         print(f"\n{Fore.CYAN}{Style.BRIGHT}▶ Running: {test_name}{Style.RESET_ALL}")
         print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}")
-    
+
     def tearDown(self):
         """Clean up after each test."""
         print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}\n")
-    
+
     def print_result_table(self, results):
         """Print results in a colorized table format."""
         headers = ["Parameter", "PSNR (dB)", "Compression Ratio"]
         colored_data = []
-        
+
         for label, psnr, ratio in results:
             # Color code PSNR values
             if psnr > 50:
@@ -73,317 +71,360 @@ class TestBasicFunctionality(unittest.TestCase):
                 psnr_colored = f"{Fore.YELLOW}{psnr:.2f}{Style.RESET_ALL}"
             else:
                 psnr_colored = f"{Fore.RED}{psnr:.2f}{Style.RESET_ALL}"
-            
+
             # Color code compression ratio values
             if ratio > 10:
-                ratio_colored = f"{Fore.GREEN}{Style.BRIGHT}{ratio:.2f}x{Style.RESET_ALL}"
+                ratio_colored = (
+                    f"{Fore.GREEN}{Style.BRIGHT}{ratio:.2f}x{Style.RESET_ALL}"
+                )
             elif ratio > 5:
                 ratio_colored = f"{Fore.GREEN}{ratio:.2f}x{Style.RESET_ALL}"
             elif ratio > 2:
                 ratio_colored = f"{Fore.YELLOW}{ratio:.2f}x{Style.RESET_ALL}"
             else:
                 ratio_colored = f"{Fore.RED}{ratio:.2f}x{Style.RESET_ALL}"
-            
+
             colored_data.append([label, psnr_colored, ratio_colored])
-        
+
         # Print the table
         print(tabulate(colored_data, headers=headers, tablefmt="simple"))
-    
+
     def test_filter_registration(self):
         """Test if the FFMPEG filter is properly registered."""
         # Check if FFMPEG filter ID is defined
-        self.assertTrue(hasattr(hf, 'FFMPEG_ID'))
-        
+        self.assertTrue(hasattr(hf, "FFMPEG_ID"))
+
         # Check if h5py can see our filter
         self.assertTrue(h5py.h5z.filter_avail(hf.FFMPEG_ID))
-        
-        print(f"{Fore.GREEN}✓ FFMPEG filter is properly registered with ID: {hf.FFMPEG_ID}{Style.RESET_ALL}")
-    
+
+        print(
+            f"{Fore.GREEN}✓ FFMPEG filter is properly registered with ID: {hf.FFMPEG_ID}{Style.RESET_ALL}"
+        )
+
     def test_basic_compression_8bit(self):
         """Test basic compression/decompression with 8-bit data."""
         # Generate 3D test data (8-bit)
-        print(f"{Fore.BLUE}ℹ Generating 8-bit test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+        print(
+            f"{Fore.BLUE}ℹ Generating 8-bit test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+        )
         test_data = generate_3d_data(
             width=self.width,
             height=self.height,
             depth=self.depth,
             dtype=np.uint8,
             pattern="random",
-            seed=self.seed
+            seed=self.seed,
         )
-        
+
         # Use H.264 compression with default settings
         compression_options = hf.x264()
-        print(f"{Fore.BLUE}ℹ Compressing with H.264 codec (default settings)...{Style.RESET_ALL}")
-        
-        # Compress and decompress
-        decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = compress_and_decompress(
-            test_data, compression_options
+        print(
+            f"{Fore.BLUE}ℹ Compressing with H.264 codec (default settings)...{Style.RESET_ALL}"
         )
-        
+
+        # Compress and decompress
+        decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = (
+            compress_and_decompress(test_data, compression_options)
+        )
+
         # Check that shapes match
         self.assertEqual(test_data.shape, decompressed_data.shape)
-        
+
         # Check that dtype matches
         self.assertEqual(test_data.dtype, decompressed_data.dtype)
-        
+
         # Calculate PSNR
         psnr = calculate_psnr(test_data, decompressed_data)
-        
+
         # Print results in color
-        results = [
-            ("8-bit (H.264)", psnr, compression_ratio)
-        ]
+        results = [("8-bit (H.264)", psnr, compression_ratio)]
         self.print_result_table(results)
-        print(f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}"
+        )
+
         # Check that PSNR is above threshold
         self.assertGreater(psnr, self.min_psnr_8bit)
-        
+
         # Check compression ratio
         self.assertGreater(compression_ratio, self.min_compression_ratio)
-    
+
     def test_basic_compression_16bit(self):
         """Test basic compression/decompression with 16-bit data."""
         # Generate 3D test data (16-bit)
-        print(f"{Fore.BLUE}ℹ Generating 16-bit test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+        print(
+            f"{Fore.BLUE}ℹ Generating 16-bit test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+        )
         test_data = generate_3d_data(
             width=self.width,
             height=self.height,
             depth=self.depth,
             dtype=np.uint16,
             pattern="random",
-            seed=self.seed
+            seed=self.seed,
         )
-        
+
         # Use H.264 compression with 10-bit color depth
         compression_options = hf.x264(bit_mode=hf.BitMode.BIT_10)
-        print(f"{Fore.BLUE}ℹ Compressing with H.264 codec (10-bit mode)...{Style.RESET_ALL}")
-        
-        # Compress and decompress
-        decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = compress_and_decompress(
-            test_data, compression_options
+        print(
+            f"{Fore.BLUE}ℹ Compressing with H.264 codec (10-bit mode)...{Style.RESET_ALL}"
         )
-        
+
+        # Compress and decompress
+        decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = (
+            compress_and_decompress(test_data, compression_options)
+        )
+
         # Check that shapes match
         self.assertEqual(test_data.shape, decompressed_data.shape)
-        
+
         # Check that dtype matches
         self.assertEqual(test_data.dtype, decompressed_data.dtype)
-        
+
         # Calculate PSNR
         psnr = calculate_psnr(test_data, decompressed_data)
-        
+
         # Print results in color
-        results = [
-            ("16-bit (H.264 10-bit)", psnr, compression_ratio)
-        ]
+        results = [("16-bit (H.264 10-bit)", psnr, compression_ratio)]
         self.print_result_table(results)
-        print(f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}"
+        )
+
         # Check that PSNR is above threshold
         self.assertGreater(psnr, self.min_psnr_16bit)
-        
+
         # Check compression ratio
         self.assertGreater(compression_ratio, self.min_compression_ratio)
-    
+
     def test_gradient_data(self):
         """Test compression with gradient data (more compressible)."""
         # Generate 3D gradient data (8-bit)
-        print(f"{Fore.BLUE}ℹ Generating gradient test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+        print(
+            f"{Fore.BLUE}ℹ Generating gradient test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+        )
         test_data = generate_3d_data(
             width=self.width,
             height=self.height,
             depth=self.depth,
             dtype=np.uint8,
             pattern="gradient",
-            seed=self.seed
+            seed=self.seed,
         )
-        
+
         # Use H.264 compression
         compression_options = hf.x264(crf=23)  # Default quality
         print(f"{Fore.BLUE}ℹ Compressing with H.264 codec (CRF=23)...{Style.RESET_ALL}")
-        
+
         # Compress and decompress
-        decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = compress_and_decompress(
-            test_data, compression_options
+        decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = (
+            compress_and_decompress(test_data, compression_options)
         )
-        
+
         # Calculate PSNR
         psnr = calculate_psnr(test_data, decompressed_data)
-        
+
         # Print results in color
-        results = [
-            ("Gradient Data", psnr, compression_ratio)
-        ]
+        results = [("Gradient Data", psnr, compression_ratio)]
         self.print_result_table(results)
-        print(f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}"
+        )
+
         # Gradient data should be more compressible than random data
         self.assertGreater(compression_ratio, self.min_compression_ratio * 2)
-    
+
     def test_stripes_data(self):
         """Test compression with striped data (highly compressible)."""
         # Generate 3D striped data (8-bit)
-        print(f"{Fore.BLUE}ℹ Generating striped test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+        print(
+            f"{Fore.BLUE}ℹ Generating striped test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+        )
         test_data = generate_3d_data(
             width=self.width,
             height=self.height,
             depth=self.depth,
             dtype=np.uint8,
             pattern="stripes",
-            seed=self.seed
+            seed=self.seed,
         )
-        
+
         # Use H.264 compression
         compression_options = hf.x264(crf=23)
         print(f"{Fore.BLUE}ℹ Compressing with H.264 codec (CRF=23)...{Style.RESET_ALL}")
-        
+
         # Compress and decompress
-        decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = compress_and_decompress(
-            test_data, compression_options
+        decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = (
+            compress_and_decompress(test_data, compression_options)
         )
-        
+
         # Calculate PSNR
         psnr = calculate_psnr(test_data, decompressed_data)
-        
+
         # Print results in color
-        results = [
-            ("Striped Data", psnr, compression_ratio)
-        ]
+        results = [("Striped Data", psnr, compression_ratio)]
         self.print_result_table(results)
-        print(f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}"
+        )
+
         # Striped data should be highly compressible
         self.assertGreater(compression_ratio, self.min_compression_ratio * 3)
 
     def test_different_quality_settings(self):
         """Test different quality settings (CRF values)."""
         # Generate 3D test data (8-bit)
-        print(f"{Fore.BLUE}ℹ Generating random test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+        print(
+            f"{Fore.BLUE}ℹ Generating random test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+        )
         test_data = generate_3d_data(
             width=self.width,
             height=self.height,
             depth=self.depth,
             dtype=np.uint8,
             pattern="random",
-            seed=self.seed
+            seed=self.seed,
         )
-        
+
         results = []
-        
+
         # Test different CRF values (lower = higher quality)
         for crf in [18, 23, 28]:
             print(f"{Fore.BLUE}ℹ Testing H.264 with CRF={crf}...{Style.RESET_ALL}")
             compression_options = hf.x264(crf=crf)
-            
+
             # Compress and decompress
-            decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = compress_and_decompress(
-                test_data, compression_options
-            )
-            
+            (
+                decompressed_data,
+                compression_ratio,
+                compressed_size,
+                enc_time,
+                dec_time,
+            ) = compress_and_decompress(test_data, compression_options)
+
             # Calculate PSNR
             psnr = calculate_psnr(test_data, decompressed_data)
             results.append((f"CRF {crf}", psnr, compression_ratio))
-            print(f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}")
-        
+            print(
+                f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}"
+            )
+
         # Print results table
         self.print_result_table(results)
-        
+
         # Lower CRF (higher quality) should give higher PSNR
         self.assertGreater(results[0][1], results[1][1])
         self.assertGreater(results[1][1], results[2][1])
-        
+
         # Higher CRF (lower quality) should give higher compression ratio
         self.assertLess(results[0][2], results[2][2])
-    
+
     def test_x265_codec(self):
         """Test H.265/HEVC codec."""
         try:
             # Generate 3D test data (8-bit)
-            print(f"{Fore.BLUE}ℹ Generating random test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+            print(
+                f"{Fore.BLUE}ℹ Generating random test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+            )
             test_data = generate_3d_data(
                 width=self.width,
                 height=self.height,
                 depth=self.depth,
                 dtype=np.uint8,
                 pattern="random",
-                seed=self.seed
+                seed=self.seed,
             )
-            
+
             # Use H.265 compression
             compression_options = hf.x265(crf=28)
-            print(f"{Fore.BLUE}ℹ Compressing with H.265/HEVC codec (CRF=28)...{Style.RESET_ALL}")
-            
-            # Compress and decompress
-            decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = compress_and_decompress(
-                test_data, compression_options
+            print(
+                f"{Fore.BLUE}ℹ Compressing with H.265/HEVC codec (CRF=28)...{Style.RESET_ALL}"
             )
-            
+
+            # Compress and decompress
+            (
+                decompressed_data,
+                compression_ratio,
+                compressed_size,
+                enc_time,
+                dec_time,
+            ) = compress_and_decompress(test_data, compression_options)
+
             # Calculate PSNR
             psnr = calculate_psnr(test_data, decompressed_data)
-            
+
             # Print results in color
-            results = [
-                ("H.265/HEVC", psnr, compression_ratio)
-            ]
+            results = [("H.265/HEVC", psnr, compression_ratio)]
             self.print_result_table(results)
-            print(f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}")
-            
+            print(
+                f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}"
+            )
+
             # H.265 should provide good quality
             self.assertGreater(psnr, self.min_psnr_8bit)
-            
+
             # H.265 should provide good compression
             self.assertGreater(compression_ratio, self.min_compression_ratio)
         except Exception as e:
             print(f"{Fore.YELLOW}⚠ HEVC codec test skipped: {str(e)}{Style.RESET_ALL}")
             self.skipTest(f"HEVC codec test skipped: {str(e)}")
-    
+
     def test_svtav1_codec(self):
         """Test AV1 codec if available."""
         try:
             # Generate 3D test data (8-bit)
-            print(f"{Fore.BLUE}ℹ Generating random test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+            print(
+                f"{Fore.BLUE}ℹ Generating random test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+            )
             test_data = generate_3d_data(
                 width=self.width,
                 height=self.height,
                 depth=self.depth,
                 dtype=np.uint8,
                 pattern="random",
-                seed=self.seed
+                seed=self.seed,
             )
-            
+
             # Use AV1 compression
             compression_options = hf.svtav1(crf=30)
-            print(f"{Fore.BLUE}ℹ Compressing with SVT-AV1 codec (CRF=30)...{Style.RESET_ALL}")
-            
-            # Compress and decompress
-            decompressed_data, compression_ratio, compressed_size, enc_time, dec_time = compress_and_decompress(
-                test_data, compression_options
+            print(
+                f"{Fore.BLUE}ℹ Compressing with SVT-AV1 codec (CRF=30)...{Style.RESET_ALL}"
             )
-            
+
+            # Compress and decompress
+            (
+                decompressed_data,
+                compression_ratio,
+                compressed_size,
+                enc_time,
+                dec_time,
+            ) = compress_and_decompress(test_data, compression_options)
+
             # Calculate PSNR
             psnr = calculate_psnr(test_data, decompressed_data)
-            
+
             # Print results in color
-            results = [
-                ("SVT-AV1", psnr, compression_ratio)
-            ]
+            results = [("SVT-AV1", psnr, compression_ratio)]
             self.print_result_table(results)
-            print(f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}")
-            
+            print(
+                f"{Fore.BLUE}ℹ Processing time: {enc_time + dec_time:.2f} seconds{Style.RESET_ALL}"
+            )
+
             # AV1 should provide good quality
             self.assertGreater(psnr, self.min_psnr_8bit)
-            
+
             # AV1 should provide good compression
             self.assertGreater(compression_ratio, self.min_compression_ratio)
         except Exception as e:
             print(f"{Fore.YELLOW}⚠ AV1 codec test skipped: {str(e)}{Style.RESET_ALL}")
             self.skipTest(f"AV1 codec test skipped: {str(e)}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     runner = ColoredTestRunner(verbosity=1)
-    result = runner.run(unittest.TestLoader().loadTestsFromTestCase(TestBasicFunctionality))
+    result = runner.run(
+        unittest.TestLoader().loadTestsFromTestCase(TestBasicFunctionality)
+    )
     print_summary("BASIC TESTS", result)
 
     sys.exit(not result.wasSuccessful())

--- a/tests/test_ffmpeg.py
+++ b/tests/test_ffmpeg.py
@@ -8,80 +8,98 @@ import subprocess
 import platform
 import pytest
 
+
 def get_ffmpeg_path():
     """Get the FFmpeg executable path based on platform."""
     root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     ffmpeg_dir = os.path.join(root_dir, "ffmpeg_build")
-    
+
     if platform.system() == "Windows":
         return os.path.join(ffmpeg_dir, "bin", "ffmpeg.exe")
     else:
         return os.path.join(ffmpeg_dir, "bin", "ffmpeg")
+
 
 def set_library_path():
     """Set the appropriate library path for the current platform."""
     root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     ffmpeg_dir = os.path.join(root_dir, "ffmpeg_build")
     lib_dir = os.path.join(ffmpeg_dir, "lib")
-    
+
     if platform.system() == "Windows":
         # Add bin directory to PATH for Windows (DLLs are in bin)
         bin_dir = os.path.join(ffmpeg_dir, "bin")
         os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
     elif platform.system() == "Darwin":  # macOS
         # Set DYLD_LIBRARY_PATH for macOS
-        os.environ["DYLD_LIBRARY_PATH"] = lib_dir + os.pathsep + os.environ.get("DYLD_LIBRARY_PATH", "")
+        os.environ["DYLD_LIBRARY_PATH"] = (
+            lib_dir + os.pathsep + os.environ.get("DYLD_LIBRARY_PATH", "")
+        )
     else:  # Linux
         # Set LD_LIBRARY_PATH for Linux
-        os.environ["LD_LIBRARY_PATH"] = lib_dir + os.pathsep + os.environ.get("LD_LIBRARY_PATH", "")
-    
+        os.environ["LD_LIBRARY_PATH"] = (
+            lib_dir + os.pathsep + os.environ.get("LD_LIBRARY_PATH", "")
+        )
+
     # Set PKG_CONFIG_PATH for all platforms
-    os.environ["PKG_CONFIG_PATH"] = os.path.join(lib_dir, "pkgconfig") + os.pathsep + os.environ.get("PKG_CONFIG_PATH", "")
+    os.environ["PKG_CONFIG_PATH"] = (
+        os.path.join(lib_dir, "pkgconfig")
+        + os.pathsep
+        + os.environ.get("PKG_CONFIG_PATH", "")
+    )
+
 
 def test_ffmpeg_version():
     """Test that FFmpeg runs and returns version information."""
     ffmpeg_path = get_ffmpeg_path()
     set_library_path()
-    
+
     try:
-        result = subprocess.run([ffmpeg_path, "-version"], 
-                               stdout=subprocess.PIPE, 
-                               stderr=subprocess.PIPE,
-                               text=True)
-        
+        result = subprocess.run(
+            [ffmpeg_path, "-version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
         assert result.returncode == 0, f"FFmpeg version command failed: {result.stderr}"
         assert "ffmpeg version" in result.stdout, "Expected version string not found"
-        
+
         print(f"FFmpeg version: {result.stdout.splitlines()[0]}")
         return True
     except Exception as e:
         pytest.fail(f"Exception occurred: {e}")
         return False
 
+
 def test_ffmpeg_codecs():
     """Test that FFmpeg supports the expected codecs."""
     ffmpeg_path = get_ffmpeg_path()
     set_library_path()
-    
+
     try:
-        result = subprocess.run([ffmpeg_path, "-encoders"], 
-                               stdout=subprocess.PIPE, 
-                               stderr=subprocess.PIPE,
-                               text=True)
-        
-        assert result.returncode == 0, f"FFmpeg encoders command failed: {result.stderr}"
-        
+        result = subprocess.run(
+            [ffmpeg_path, "-encoders"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        assert (
+            result.returncode == 0
+        ), f"FFmpeg encoders command failed: {result.stderr}"
+
         encoders = result.stdout
-        
+
         # Check for important codecs - at least one should be found
         important_codecs = ["264", "265", "av1", "vp9"]
         found_codecs = [codec for codec in important_codecs if codec in encoders]
-        
+
         assert len(found_codecs) > 0, "No important codecs were found"
-        
+
         for codec in found_codecs:
             print(f"Found codec: {codec}")
-        
+
         return True
     except Exception as e:
         pytest.fail(f"Exception occurred: {e}")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,68 +26,74 @@ from h5ffmpeg.utils import *
 # Import test utilities
 from test_utils import generate_3d_data
 
-from colored_test import (
-    ColoredTestRunner,
-    print_summary
-)
+from colored_test import ColoredTestRunner, print_summary
+
 
 class TestIntegration(unittest.TestCase):
     """
     Test integration of the FFMPEG HDF5 filter with h5py and other libraries.
     """
-    
+
     def setUp(self):
         """Set up test parameters."""
         # Define dimensions for the test data
         self.width = 256
         self.height = 256
         self.depth = 50
-        
+
         # Set random seed for reproducibility
         self.seed = 42
-        
+
         # Generate test data once for all tests
-        print(f"{Fore.BLUE}ℹ Generating 8-bit test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+        print(
+            f"{Fore.BLUE}ℹ Generating 8-bit test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+        )
         self.test_data_8bit = generate_3d_data(
             width=self.width,
             height=self.height,
             depth=self.depth,
             dtype=np.uint8,
             pattern="stripes",
-            seed=self.seed
+            seed=self.seed,
         )
-        
-        print(f"{Fore.BLUE}ℹ Generating 16-bit test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}")
+
+        print(
+            f"{Fore.BLUE}ℹ Generating 16-bit test data ({self.depth}x{self.height}x{self.width})...{Style.RESET_ALL}"
+        )
         self.test_data_16bit = generate_3d_data(
             width=self.width,
             height=self.height,
             depth=self.depth,
             dtype=np.uint16,
             pattern="stripes",
-            seed=self.seed
+            seed=self.seed,
         )
-        
+
         # Create a temporary directory for test files
         self.temp_dir = tempfile.mkdtemp()
-        print(f"{Fore.BLUE}ℹ Created temporary directory for test files: {self.temp_dir}{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Created temporary directory for test files: {self.temp_dir}{Style.RESET_ALL}"
+        )
+
         # Print test header
         test_name = self._testMethodName
         print(f"\n{Fore.CYAN}{Style.BRIGHT}▶ Running: {test_name}{Style.RESET_ALL}")
         print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}")
-    
+
     def tearDown(self):
         """Clean up after tests."""
         # Remove temporary directory and its contents
         shutil.rmtree(self.temp_dir)
-        print(f"{Fore.BLUE}ℹ Removed temporary directory and test files{Style.RESET_ALL}")
+        print(
+            f"{Fore.BLUE}ℹ Removed temporary directory and test files{Style.RESET_ALL}"
+        )
         print(f"{Fore.CYAN}{'─' * 60}{Style.RESET_ALL}\n")
-    
+
     def print_result_table(self, results):
         """Print results in a colorized table format."""
         headers = ["Dataset", "PSNR (dB)", "Compression Ratio", "File Size (KB)"]
         colored_data = []
-        
+
         for label, psnr, ratio, size_kb in results:
             # Color code PSNR values
             if psnr > 50:
@@ -98,558 +104,651 @@ class TestIntegration(unittest.TestCase):
                 psnr_colored = f"{Fore.YELLOW}{psnr:.2f}{Style.RESET_ALL}"
             else:
                 psnr_colored = f"{Fore.RED}{psnr:.2f}{Style.RESET_ALL}"
-            
+
             # Color code compression ratio values
             if ratio > 10:
-                ratio_colored = f"{Fore.GREEN}{Style.BRIGHT}{ratio:.2f}x{Style.RESET_ALL}"
+                ratio_colored = (
+                    f"{Fore.GREEN}{Style.BRIGHT}{ratio:.2f}x{Style.RESET_ALL}"
+                )
             elif ratio > 5:
                 ratio_colored = f"{Fore.GREEN}{ratio:.2f}x{Style.RESET_ALL}"
             elif ratio > 2:
                 ratio_colored = f"{Fore.YELLOW}{ratio:.2f}x{Style.RESET_ALL}"
             else:
                 ratio_colored = f"{Fore.RED}{ratio:.2f}x{Style.RESET_ALL}"
-            
+
             # Color code file size
             if size_kb < 100:
-                size_colored = f"{Fore.GREEN}{Style.BRIGHT}{size_kb:.1f}{Style.RESET_ALL}"
+                size_colored = (
+                    f"{Fore.GREEN}{Style.BRIGHT}{size_kb:.1f}{Style.RESET_ALL}"
+                )
             elif size_kb < 500:
                 size_colored = f"{Fore.GREEN}{size_kb:.1f}{Style.RESET_ALL}"
             elif size_kb < 1000:
                 size_colored = f"{Fore.YELLOW}{size_kb:.1f}{Style.RESET_ALL}"
             else:
                 size_colored = f"{Fore.RED}{size_kb:.1f}{Style.RESET_ALL}"
-            
+
             colored_data.append([label, psnr_colored, ratio_colored, size_colored])
-        
+
         # Print the table
         print(tabulate(colored_data, headers=headers, tablefmt="simple"))
-    
+
     def test_h5py_integration(self):
         """Test basic integration with h5py."""
         # Create a temporary HDF5 file
         h5_file = os.path.join(self.temp_dir, "test_h5py.h5")
         print(f"{Fore.BLUE}ℹ Testing basic integration with h5py...{Style.RESET_ALL}")
-        
+
         # Compression options
         compression_options = hf.x264(crf=23)
         print(f"{Fore.BLUE}ℹ Using H.264 compression with CRF=23{Style.RESET_ALL}")
-        
+
         # Write data with compression
         print(f"{Fore.BLUE}ℹ Writing compressed data to HDF5 file...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'w') as f:
+        with h5py.File(h5_file, "w") as f:
             f.create_dataset("data", data=self.test_data_8bit, **compression_options)
-        
+
         file_size_kb = os.path.getsize(h5_file) / 1024
         print(f"{Fore.BLUE}ℹ File size: {file_size_kb:.1f} KB{Style.RESET_ALL}")
-        
+
         # Read back the data
         print(f"{Fore.BLUE}ℹ Reading back compressed data...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'r') as f:
+        with h5py.File(h5_file, "r") as f:
             # Read data
             decompressed_data = f["data"][:]
-            
+
             # Check shape and dtype
             self.assertEqual(decompressed_data.shape, self.test_data_8bit.shape)
             self.assertEqual(decompressed_data.dtype, self.test_data_8bit.dtype)
             print(f"{Fore.GREEN}✓ Shape and dtype match original data{Style.RESET_ALL}")
-            
+
             # Check quality
             psnr = calculate_psnr(self.test_data_8bit, decompressed_data)
             print(f"{Fore.BLUE}ℹ PSNR: {psnr:.2f} dB{Style.RESET_ALL}")
             self.assertGreater(psnr, 40.0)
-            
+
             # Calculate compression ratio
             original_size = self.test_data_8bit.nbytes
             compressed_size = os.path.getsize(h5_file)
             compression_ratio = original_size / compressed_size
-            
+
             # Print results table
-            results = [
-                ("H.264 (CRF=23)", psnr, compression_ratio, file_size_kb)
-            ]
+            results = [("H.264 (CRF=23)", psnr, compression_ratio, file_size_kb)]
             self.print_result_table(results)
-    
+
     def test_chunked_dataset(self):
         """Test with chunked datasets."""
         # Create a temporary HDF5 file
         h5_file = os.path.join(self.temp_dir, "test_chunked.h5")
-        print(f"{Fore.BLUE}ℹ Testing compression with different chunk sizes...{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Testing compression with different chunk sizes...{Style.RESET_ALL}"
+        )
+
         # Different chunk sizes to test
         chunk_sizes = [
-            (10, 64, 64),   # Small chunks
-            (50, 256, 256), # One big chunk
-            (5, 128, 128)   # Medium chunks
+            (10, 64, 64),  # Small chunks
+            (50, 256, 256),  # One big chunk
+            (5, 128, 128),  # Medium chunks
         ]
-        
+
         results = []
-        
+
         for i, chunks in enumerate(chunk_sizes):
             dataset_name = f"data_{i}"
             chunk_label = f"Chunks {chunks}"
-            
+
             print(f"{Fore.BLUE}ℹ Testing with chunk size {chunks}...{Style.RESET_ALL}")
 
             # Compression options
             compression_options = hf.x264(crf=23)
-            
+
             # Write data with compression and specified chunks
-            with h5py.File(h5_file, 'w') as f:
+            with h5py.File(h5_file, "w") as f:
                 f.create_dataset(
-                    dataset_name, 
+                    dataset_name,
                     data=self.test_data_8bit,
                     chunks=chunks,
-                    **compression_options
+                    **compression_options,
                 )
-            
+
             file_size_kb = os.path.getsize(h5_file) / 1024
-            
+
             # Read back the data
-            with h5py.File(h5_file, 'r') as f:
+            with h5py.File(h5_file, "r") as f:
                 # Check that chunks are as specified
                 dataset = f[dataset_name]
                 self.assertEqual(dataset.chunks, chunks)
-                
+
                 # Read data
                 decompressed_data = dataset[:]
-                
+
                 # Check quality
                 psnr = calculate_psnr(self.test_data_8bit, decompressed_data)
-                
+
                 # Calculate compression ratio
                 original_size = self.test_data_8bit.nbytes
                 compressed_size = os.path.getsize(h5_file)
                 compression_ratio = original_size / compressed_size
-                
+
                 results.append((chunk_label, psnr, compression_ratio, file_size_kb))
-        
+
         # Print results table
         self.print_result_table(results)
-        
+
         # Verify all PSNRs are acceptable
         for label, psnr, ratio, _ in results:
             self.assertGreater(psnr, 40.0, f"PSNR for {label} is too low")
-        
-        print(f"{Fore.GREEN}✓ All chunk sizes provide acceptable quality (PSNR > 40 dB){Style.RESET_ALL}")
-    
+
+        print(
+            f"{Fore.GREEN}✓ All chunk sizes provide acceptable quality (PSNR > 40 dB){Style.RESET_ALL}"
+        )
+
     def test_partial_reads(self):
         """Test partial dataset reads."""
         # Create a temporary HDF5 file
         h5_file = os.path.join(self.temp_dir, "test_partial.h5")
         print(f"{Fore.BLUE}ℹ Testing partial dataset reads...{Style.RESET_ALL}")
-        
+
         # Write data with compression
-        print(f"{Fore.BLUE}ℹ Writing compressed dataset with chunks...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'w') as f:
+        print(
+            f"{Fore.BLUE}ℹ Writing compressed dataset with chunks...{Style.RESET_ALL}"
+        )
+        with h5py.File(h5_file, "w") as f:
             f.create_dataset(
-                "data",
-                data=self.test_data_8bit,
-                chunks=(10, 64, 64),
-                **hf.x264(crf=23)
+                "data", data=self.test_data_8bit, chunks=(10, 64, 64), **hf.x264(crf=23)
             )
-        
+
         # Read parts of the data
-        print(f"{Fore.BLUE}ℹ Reading partial sections of the dataset...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'r') as f:
+        print(
+            f"{Fore.BLUE}ℹ Reading partial sections of the dataset...{Style.RESET_ALL}"
+        )
+        with h5py.File(h5_file, "r") as f:
             dataset = f["data"]
-            
+
             # Read first 10 slices
             print(f"{Fore.BLUE}ℹ Reading first 10 slices...{Style.RESET_ALL}")
             partial_data = dataset[0:10, :, :]
             self.assertEqual(partial_data.shape, (10, self.height, self.width))
-            print(f"{Fore.GREEN}✓ First 10 slices read successfully with shape {partial_data.shape}{Style.RESET_ALL}")
-            
+            print(
+                f"{Fore.GREEN}✓ First 10 slices read successfully with shape {partial_data.shape}{Style.RESET_ALL}"
+            )
+
             # Read middle region
-            print(f"{Fore.BLUE}ℹ Reading middle region (20:30, 50:150, 50:150)...{Style.RESET_ALL}")
+            print(
+                f"{Fore.BLUE}ℹ Reading middle region (20:30, 50:150, 50:150)...{Style.RESET_ALL}"
+            )
             partial_data = dataset[20:30, 50:150, 50:150]
             self.assertEqual(partial_data.shape, (10, 100, 100))
-            print(f"{Fore.GREEN}✓ Middle region read successfully with shape {partial_data.shape}{Style.RESET_ALL}")
-            
+            print(
+                f"{Fore.GREEN}✓ Middle region read successfully with shape {partial_data.shape}{Style.RESET_ALL}"
+            )
+
             # Read single slice
             print(f"{Fore.BLUE}ℹ Reading single slice (index 25)...{Style.RESET_ALL}")
             partial_data = dataset[25, :, :]
             self.assertEqual(partial_data.shape, (self.height, self.width))
-            print(f"{Fore.GREEN}✓ Single slice read successfully with shape {partial_data.shape}{Style.RESET_ALL}")
-    
+            print(
+                f"{Fore.GREEN}✓ Single slice read successfully with shape {partial_data.shape}{Style.RESET_ALL}"
+            )
+
     def test_data_types(self):
         """Test with different data types."""
         # Create a temporary HDF5 file
         h5_file = os.path.join(self.temp_dir, "test_datatypes.h5")
-        print(f"{Fore.BLUE}ℹ Testing compression with different data types...{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Testing compression with different data types...{Style.RESET_ALL}"
+        )
+
         # Test with 8-bit and 16-bit data
         datasets = [
             ("data_8bit", self.test_data_8bit, hf.x264()),
-            ("data_16bit", self.test_data_16bit, hf.x264(bit_mode=hf.BitMode.BIT_10))
+            ("data_16bit", self.test_data_16bit, hf.x264(bit_mode=hf.BitMode.BIT_10)),
         ]
-        
+
         # Write datasets
         print(f"{Fore.BLUE}ℹ Writing 8-bit and 16-bit datasets...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'w') as f:
+        with h5py.File(h5_file, "w") as f:
             for name, data, options in datasets:
                 print(f"{Fore.BLUE}ℹ Writing {name} dataset...{Style.RESET_ALL}")
                 f.create_dataset(name, data=data, **options)
-        
+
         # Read datasets
         results = []
-        print(f"{Fore.BLUE}ℹ Reading back datasets and calculating metrics...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'r') as f:
+        print(
+            f"{Fore.BLUE}ℹ Reading back datasets and calculating metrics...{Style.RESET_ALL}"
+        )
+        with h5py.File(h5_file, "r") as f:
             for name, data, _ in datasets:
                 print(f"{Fore.BLUE}ℹ Reading {name} dataset...{Style.RESET_ALL}")
                 # Read data
                 decompressed_data = f[name][:]
-                
+
                 # Check shape and dtype
                 self.assertEqual(decompressed_data.shape, data.shape)
                 self.assertEqual(decompressed_data.dtype, data.dtype)
-                print(f"{Fore.GREEN}✓ Shape and dtype match for {name}{Style.RESET_ALL}")
-                
+                print(
+                    f"{Fore.GREEN}✓ Shape and dtype match for {name}{Style.RESET_ALL}"
+                )
+
                 # Check quality
                 psnr = calculate_psnr(data, decompressed_data)
-                
+
                 # Calculate approximate size for this dataset
                 # This is an approximation since the file contains multiple datasets
                 file_info = os.stat(h5_file)
                 file_size_kb = file_info.st_size / 1024 / len(datasets)
-                
+
                 # Calculate approximate compression ratio
                 original_size = data.nbytes
                 compression_ratio = original_size / (file_size_kb * 1024)
-                
+
                 results.append((name, psnr, compression_ratio, file_size_kb))
-                
+
                 # PSNR threshold depends on bit depth
                 min_psnr = 40.0 if name == "data_8bit" else 45.0
                 self.assertGreater(psnr, min_psnr, f"PSNR for {name} is too low")
-                print(f"{Fore.GREEN}✓ {name} has acceptable quality (PSNR > {min_psnr} dB){Style.RESET_ALL}")
-        
+                print(
+                    f"{Fore.GREEN}✓ {name} has acceptable quality (PSNR > {min_psnr} dB){Style.RESET_ALL}"
+                )
+
         # Print results table
         self.print_result_table(results)
-    
+
     def test_hierarchical_groups(self):
         """Test with hierarchical groups."""
         # Create a temporary HDF5 file
         h5_file = os.path.join(self.temp_dir, "test_groups.h5")
-        print(f"{Fore.BLUE}ℹ Testing hierarchical group structure with compressed datasets...{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Testing hierarchical group structure with compressed datasets...{Style.RESET_ALL}"
+        )
+
         # Compression options
         compression_options = hf.x264(crf=23)
-        
+
         # Create hierarchical structure
         print(f"{Fore.BLUE}ℹ Creating hierarchical group structure...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'w') as f:
+        with h5py.File(h5_file, "w") as f:
             # Create groups
             group1 = f.create_group("group1")
             group2 = group1.create_group("group2")
-            
+
             # Create datasets at different levels
-            print(f"{Fore.BLUE}ℹ Creating compressed dataset at root level...{Style.RESET_ALL}")
-            f.create_dataset("root_data", data=self.test_data_8bit, **compression_options)
-            
-            print(f"{Fore.BLUE}ℹ Creating compressed dataset at level 1...{Style.RESET_ALL}")
-            group1.create_dataset("level1_data", data=self.test_data_8bit, **compression_options)
-            
-            print(f"{Fore.BLUE}ℹ Creating compressed dataset at level 2...{Style.RESET_ALL}")
-            group2.create_dataset("level2_data", data=self.test_data_8bit, **compression_options)
-        
+            print(
+                f"{Fore.BLUE}ℹ Creating compressed dataset at root level...{Style.RESET_ALL}"
+            )
+            f.create_dataset(
+                "root_data", data=self.test_data_8bit, **compression_options
+            )
+
+            print(
+                f"{Fore.BLUE}ℹ Creating compressed dataset at level 1...{Style.RESET_ALL}"
+            )
+            group1.create_dataset(
+                "level1_data", data=self.test_data_8bit, **compression_options
+            )
+
+            print(
+                f"{Fore.BLUE}ℹ Creating compressed dataset at level 2...{Style.RESET_ALL}"
+            )
+            group2.create_dataset(
+                "level2_data", data=self.test_data_8bit, **compression_options
+            )
+
         # Read datasets from different levels
-        print(f"{Fore.BLUE}ℹ Reading datasets from different hierarchy levels...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'r') as f:
+        print(
+            f"{Fore.BLUE}ℹ Reading datasets from different hierarchy levels...{Style.RESET_ALL}"
+        )
+        with h5py.File(h5_file, "r") as f:
             # Check root level
             print(f"{Fore.BLUE}ℹ Reading root level dataset...{Style.RESET_ALL}")
             root_data = f["root_data"][:]
             self.assertEqual(root_data.shape, self.test_data_8bit.shape)
-            print(f"{Fore.GREEN}✓ Root level dataset read successfully{Style.RESET_ALL}")
-            
+            print(
+                f"{Fore.GREEN}✓ Root level dataset read successfully{Style.RESET_ALL}"
+            )
+
             # Check level 1
             print(f"{Fore.BLUE}ℹ Reading level 1 dataset...{Style.RESET_ALL}")
             level1_data = f["group1/level1_data"][:]
             self.assertEqual(level1_data.shape, self.test_data_8bit.shape)
             print(f"{Fore.GREEN}✓ Level 1 dataset read successfully{Style.RESET_ALL}")
-            
+
             # Check level 2
             print(f"{Fore.BLUE}ℹ Reading level 2 dataset...{Style.RESET_ALL}")
             level2_data = f["group1/group2/level2_data"][:]
             self.assertEqual(level2_data.shape, self.test_data_8bit.shape)
             print(f"{Fore.GREEN}✓ Level 2 dataset read successfully{Style.RESET_ALL}")
-            
+
             # Calculate PSNR for all levels
             root_psnr = calculate_psnr(self.test_data_8bit, root_data)
             level1_psnr = calculate_psnr(self.test_data_8bit, level1_data)
             level2_psnr = calculate_psnr(self.test_data_8bit, level2_data)
-            
+
             # Calculate file size
             file_size_kb = os.path.getsize(h5_file) / 1024
-            
+
             # Print results
             print(f"{Fore.BLUE}ℹ PSNR values:{Style.RESET_ALL}")
             print(f"{Fore.BLUE}ℹ Root level: {root_psnr:.2f} dB{Style.RESET_ALL}")
             print(f"{Fore.BLUE}ℹ Level 1: {level1_psnr:.2f} dB{Style.RESET_ALL}")
             print(f"{Fore.BLUE}ℹ Level 2: {level2_psnr:.2f} dB{Style.RESET_ALL}")
-            
+
             # Verify quality
             self.assertGreater(root_psnr, 40.0)
             self.assertGreater(level1_psnr, 40.0)
             self.assertGreater(level2_psnr, 40.0)
-            print(f"{Fore.GREEN}✓ All hierarchical datasets have good quality (PSNR > 40 dB){Style.RESET_ALL}")
-    
+            print(
+                f"{Fore.GREEN}✓ All hierarchical datasets have good quality (PSNR > 40 dB){Style.RESET_ALL}"
+            )
+
     def test_attributes(self):
         """Test with dataset and group attributes."""
         # Create a temporary HDF5 file
         h5_file = os.path.join(self.temp_dir, "test_attributes.h5")
-        print(f"{Fore.BLUE}ℹ Testing dataset and group attributes with compression...{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Testing dataset and group attributes with compression...{Style.RESET_ALL}"
+        )
+
         # Compression options
         compression_options = hf.x264(crf=23)
-        
+
         # Create file with attributes
-        print(f"{Fore.BLUE}ℹ Creating file with attributes at various levels...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'w') as f:
+        print(
+            f"{Fore.BLUE}ℹ Creating file with attributes at various levels...{Style.RESET_ALL}"
+        )
+        with h5py.File(h5_file, "w") as f:
             # Root attributes
             f.attrs["description"] = "Test file for FFMPEG HDF5 filter"
             f.attrs["creation_date"] = "2023-01-01"
-            
+
             # Create dataset with attributes
-            dset = f.create_dataset("data", data=self.test_data_8bit, **compression_options)
+            dset = f.create_dataset(
+                "data", data=self.test_data_8bit, **compression_options
+            )
             dset.attrs["codec"] = "H.264"
             dset.attrs["crf"] = 23
             dset.attrs["dimensions"] = [self.depth, self.height, self.width]
-            
+
             # Create group with attributes
             group = f.create_group("metadata")
             group.attrs["version"] = "1.0"
-        
+
         # Read attributes
-        print(f"{Fore.BLUE}ℹ Reading back attributes from various levels...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'r') as f:
+        print(
+            f"{Fore.BLUE}ℹ Reading back attributes from various levels...{Style.RESET_ALL}"
+        )
+        with h5py.File(h5_file, "r") as f:
             # Check root attributes
             print(f"{Fore.BLUE}ℹ Checking root attributes...{Style.RESET_ALL}")
             self.assertEqual(f.attrs["description"], "Test file for FFMPEG HDF5 filter")
             self.assertEqual(f.attrs["creation_date"], "2023-01-01")
             print(f"{Fore.GREEN}✓ Root attributes verified{Style.RESET_ALL}")
-            
+
             # Check dataset attributes
             print(f"{Fore.BLUE}ℹ Checking dataset attributes...{Style.RESET_ALL}")
             dset = f["data"]
             self.assertEqual(dset.attrs["codec"], "H.264")
             self.assertEqual(dset.attrs["crf"], 23)
             np.testing.assert_array_equal(
-                dset.attrs["dimensions"],
-                [self.depth, self.height, self.width]
+                dset.attrs["dimensions"], [self.depth, self.height, self.width]
             )
             print(f"{Fore.GREEN}✓ Dataset attributes verified{Style.RESET_ALL}")
-            
+
             # Check group attributes
             print(f"{Fore.BLUE}ℹ Checking group attributes...{Style.RESET_ALL}")
             group = f["metadata"]
             self.assertEqual(group.attrs["version"], "1.0")
             print(f"{Fore.GREEN}✓ Group attributes verified{Style.RESET_ALL}")
-            
+
             # Read and check data quality
             decompressed_data = dset[:]
             psnr = calculate_psnr(self.test_data_8bit, decompressed_data)
-            print(f"{Fore.BLUE}ℹ PSNR for dataset with attributes: {psnr:.2f} dB{Style.RESET_ALL}")
+            print(
+                f"{Fore.BLUE}ℹ PSNR for dataset with attributes: {psnr:.2f} dB{Style.RESET_ALL}"
+            )
             self.assertGreater(psnr, 40.0)
-    
+
     def test_h5py_filter_pipeline(self):
         """Test with multiple filters in h5py pipeline."""
         # Skip if h5py version doesn't support filter pipeline
         try:
             # Create a temporary HDF5 file
             h5_file = os.path.join(self.temp_dir, "test_pipeline.h5")
-            print(f"{Fore.BLUE}ℹ Testing filter pipeline with multiple filters...{Style.RESET_ALL}")
-            
+            print(
+                f"{Fore.BLUE}ℹ Testing filter pipeline with multiple filters...{Style.RESET_ALL}"
+            )
+
             # Compression options for FFMPEG
             ffmpeg_options = {
-                'compression': hf.FFMPEG_ID,
-                'compression_opts': hf.x264(crf=23)['compression_opts']
+                "compression": hf.FFMPEG_ID,
+                "compression_opts": hf.x264(crf=23)["compression_opts"],
             }
-            
+
             # Try to use FFMPEG filter with shuffle filter
-            print(f"{Fore.BLUE}ℹ Creating dataset with both FFMPEG and shuffle filters...{Style.RESET_ALL}")
-            with h5py.File(h5_file, 'w') as f:
+            print(
+                f"{Fore.BLUE}ℹ Creating dataset with both FFMPEG and shuffle filters...{Style.RESET_ALL}"
+            )
+            with h5py.File(h5_file, "w") as f:
                 dset = f.create_dataset(
-                    "data", 
+                    "data",
                     data=self.test_data_8bit,
                     **ffmpeg_options,
-                    shuffle=True  # Add byte shuffle filter, just for testing, actually doesn't make sense, IDK why am I doing it :)
+                    shuffle=True,  # Add byte shuffle filter, just for testing, actually doesn't make sense, IDK why am I doing it :)
                 )
-            
+
             # Read data
-            print(f"{Fore.BLUE}ℹ Reading back data compressed with multiple filters...{Style.RESET_ALL}")
-            with h5py.File(h5_file, 'r') as f:
+            print(
+                f"{Fore.BLUE}ℹ Reading back data compressed with multiple filters...{Style.RESET_ALL}"
+            )
+            with h5py.File(h5_file, "r") as f:
                 decompressed_data = f["data"][:]
-                
+
                 # Check quality
                 psnr = calculate_psnr(self.test_data_8bit, decompressed_data)
-                print(f"{Fore.BLUE}ℹ PSNR with filter pipeline: {psnr:.2f} dB{Style.RESET_ALL}")
+                print(
+                    f"{Fore.BLUE}ℹ PSNR with filter pipeline: {psnr:.2f} dB{Style.RESET_ALL}"
+                )
                 self.assertGreater(psnr, 40.0)
-                
+
                 # Calculate file size and compression ratio
                 file_size_kb = os.path.getsize(h5_file) / 1024
                 original_size = self.test_data_8bit.nbytes
                 compression_ratio = original_size / (file_size_kb * 1024)
-                
+
                 # Print results
-                results = [
-                    ("FFMPEG + Shuffle", psnr, compression_ratio, file_size_kb)
-                ]
+                results = [("FFMPEG + Shuffle", psnr, compression_ratio, file_size_kb)]
                 self.print_result_table(results)
-                
+
                 print(f"{Fore.GREEN}✓ Filter pipeline test passed{Style.RESET_ALL}")
-        
+
         except Exception as e:
-            print(f"{Fore.YELLOW}⚠ Filter pipeline test skipped: {str(e)}{Style.RESET_ALL}")
+            print(
+                f"{Fore.YELLOW}⚠ Filter pipeline test skipped: {str(e)}{Style.RESET_ALL}"
+            )
             self.skipTest(f"Filter pipeline test skipped: {str(e)}")
-    
+
     def test_mixed_compression(self):
         """Test with mixed compressed and uncompressed datasets."""
         # Create a temporary HDF5 file
         h5_file = os.path.join(self.temp_dir, "test_mixed.h5")
-        print(f"{Fore.BLUE}ℹ Testing file with mixed compressed and uncompressed datasets...{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Testing file with mixed compressed and uncompressed datasets...{Style.RESET_ALL}"
+        )
+
         # Compression options
         compression_options = hf.x264(crf=23)
-        
+
         # Write data
-        print(f"{Fore.BLUE}ℹ Writing compressed and uncompressed datasets to same file...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'w') as f:
+        print(
+            f"{Fore.BLUE}ℹ Writing compressed and uncompressed datasets to same file...{Style.RESET_ALL}"
+        )
+        with h5py.File(h5_file, "w") as f:
             # Compressed dataset
             print(f"{Fore.BLUE}ℹ Creating compressed dataset...{Style.RESET_ALL}")
-            f.create_dataset("compressed", data=self.test_data_8bit, **compression_options)
-            
+            f.create_dataset(
+                "compressed", data=self.test_data_8bit, **compression_options
+            )
+
             # Uncompressed dataset
             print(f"{Fore.BLUE}ℹ Creating uncompressed dataset...{Style.RESET_ALL}")
             f.create_dataset("uncompressed", data=self.test_data_8bit)
-        
+
         # Read data
         print(f"{Fore.BLUE}ℹ Reading both datasets back...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'r') as f:
+        with h5py.File(h5_file, "r") as f:
             compressed_data = f["compressed"]
             uncompressed_data = f["uncompressed"]
-            
+
             # Read both datasets
             comp_data = compressed_data[:]
             uncomp_data = uncompressed_data[:]
-            
+
             # Check shapes
             self.assertEqual(comp_data.shape, uncomp_data.shape)
             print(f"{Fore.GREEN}✓ Both datasets have same shape{Style.RESET_ALL}")
-            
+
             # Check quality
             psnr = calculate_psnr(uncomp_data, comp_data)
-            print(f"{Fore.BLUE}ℹ Compressed vs. Uncompressed: PSNR = {psnr:.2f} dB{Style.RESET_ALL}")
+            print(
+                f"{Fore.BLUE}ℹ Compressed vs. Uncompressed: PSNR = {psnr:.2f} dB{Style.RESET_ALL}"
+            )
             self.assertGreater(psnr, 40.0)
-            print(f"{Fore.GREEN}✓ Compressed data matches uncompressed with high quality (PSNR > 40 dB){Style.RESET_ALL}")
-            
+            print(
+                f"{Fore.GREEN}✓ Compressed data matches uncompressed with high quality (PSNR > 40 dB){Style.RESET_ALL}"
+            )
+
             # Calculate file size
             file_size_kb = os.path.getsize(h5_file) / 1024
-            print(f"{Fore.BLUE}ℹ Total file size: {file_size_kb:.1f} KB{Style.RESET_ALL}")
-    
+            print(
+                f"{Fore.BLUE}ℹ Total file size: {file_size_kb:.1f} KB{Style.RESET_ALL}"
+            )
+
     def test_delayed_data_setting(self):
         """Test creating datasets without initial data and setting data later."""
         # Create a temporary HDF5 file
         h5_file = os.path.join(self.temp_dir, "test_delayed_data.h5")
-        print(f"{Fore.BLUE}ℹ Testing datasets created without initial data...{Style.RESET_ALL}")
-        
+        print(
+            f"{Fore.BLUE}ℹ Testing datasets created without initial data...{Style.RESET_ALL}"
+        )
+
         # Compression options
         compression_options = hf.x264(crf=23)
-        
+
         # Create file with empty dataset and set data later
-        print(f"{Fore.BLUE}ℹ Creating empty dataset with compression...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'w') as f:
+        print(
+            f"{Fore.BLUE}ℹ Creating empty dataset with compression...{Style.RESET_ALL}"
+        )
+        with h5py.File(h5_file, "w") as f:
             # Create empty dataset with same shape as test data
             dset = f.create_dataset(
-                "delayed_data", 
+                "delayed_data",
                 shape=self.test_data_8bit.shape,
                 dtype=np.uint8,
                 chunks=(10, 64, 64),
-                **compression_options
+                **compression_options,
             )
-            
+
             print(f"{Fore.BLUE}ℹ Setting data in slices...{Style.RESET_ALL}")
-            
+
             dset[0:10, :, :] = self.test_data_8bit[0:10, :, :]
             dset[10:40, :, :] = self.test_data_8bit[10:40, :, :]
             dset[40:50, :, :] = self.test_data_8bit[40:50, :, :]
-            
-            print(f"{Fore.BLUE}ℹ Creating dataset for single value setting...{Style.RESET_ALL}")
+
+            print(
+                f"{Fore.BLUE}ℹ Creating dataset for single value setting...{Style.RESET_ALL}"
+            )
             single_dset = f.create_dataset(
                 "single_values",
                 shape=(100, 100, 100),
                 dtype=np.uint8,
                 chunks=(10, 50, 50),
-                **compression_options
+                **compression_options,
             )
-            
+
             # Set individual values
             print(f"{Fore.BLUE}ℹ Setting individual values...{Style.RESET_ALL}")
-            single_dset[0:50, 0:50, 0:50] = 100 
-            single_dset[50:100, 50:100, 50:100] = 200 
+            single_dset[0:50, 0:50, 0:50] = 100
+            single_dset[50:100, 50:100, 50:100] = 200
 
         # Read data back and verify
         print(f"{Fore.BLUE}ℹ Reading back data and verifying...{Style.RESET_ALL}")
-        with h5py.File(h5_file, 'r') as f:
+        with h5py.File(h5_file, "r") as f:
             read_data = f["delayed_data"][:]
-            
+
             self.assertEqual(read_data.shape, self.test_data_8bit.shape)
             psnr = calculate_psnr(self.test_data_8bit, read_data)
-            print(f"{Fore.BLUE}ℹ PSNR for delayed data setting: {psnr:.2f} dB{Style.RESET_ALL}")
+            print(
+                f"{Fore.BLUE}ℹ PSNR for delayed data setting: {psnr:.2f} dB{Style.RESET_ALL}"
+            )
             self.assertGreater(psnr, 40.0)
-            
+
             single_read = f["single_values"][:]
-            
+
             region1 = single_read[0:50, 0:50, 0:50]
             region2 = single_read[50:100, 50:100, 50:100]
-            
+
             mean_value_region1 = np.mean(region1)
             mean_value_region2 = np.mean(region2)
-            
-            print(f"{Fore.BLUE}ℹ Mean value in region 1: {mean_value_region1:.2f} (expected ~100){Style.RESET_ALL}")
-            print(f"{Fore.BLUE}ℹ Mean value in region 2: {mean_value_region2:.2f} (expected ~200){Style.RESET_ALL}")
-            
+
+            print(
+                f"{Fore.BLUE}ℹ Mean value in region 1: {mean_value_region1:.2f} (expected ~100){Style.RESET_ALL}"
+            )
+            print(
+                f"{Fore.BLUE}ℹ Mean value in region 2: {mean_value_region2:.2f} (expected ~200){Style.RESET_ALL}"
+            )
+
             # Assert with tolerance for compression artifacts
             self.assertGreater(mean_value_region1, 95)  # Lower bound
-            self.assertLess(mean_value_region1, 105)    # Upper bound
+            self.assertLess(mean_value_region1, 105)  # Upper bound
             self.assertGreater(mean_value_region2, 195)  # Lower bound
-            self.assertLess(mean_value_region2, 205)    # Upper bound
-            
-            print(f"{Fore.GREEN}✓ Delayed data setting and single value setting tests passed{Style.RESET_ALL}")
-            
+            self.assertLess(mean_value_region2, 205)  # Upper bound
+
+            print(
+                f"{Fore.GREEN}✓ Delayed data setting and single value setting tests passed{Style.RESET_ALL}"
+            )
+
             file_size_kb = os.path.getsize(h5_file) / 1024
-            
+
             original_size_delayed = self.test_data_8bit.nbytes
             original_size_single = 100 * 100 * 100
-            
+
             total_uncompressed = original_size_delayed + original_size_single
             delayed_ratio = original_size_delayed / total_uncompressed
             single_ratio = original_size_single / total_uncompressed
-            
+
             delayed_size_kb = file_size_kb * delayed_ratio
             single_size_kb = file_size_kb * single_ratio
-            
+
             delayed_compression = original_size_delayed / (delayed_size_kb * 1024)
             single_compression = original_size_single / (single_size_kb * 1024)
-            
+
             results = [
                 ("Delayed Data Setting", psnr, delayed_compression, delayed_size_kb),
-                ("Single Value Setting", float('inf'), single_compression, single_size_kb)
+                (
+                    "Single Value Setting",
+                    float("inf"),
+                    single_compression,
+                    single_size_kb,
+                ),
             ]
             self.print_result_table(results)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Run tests with colored output
-    print(f"{Fore.CYAN}{Style.BRIGHT}▶ FFMPEG HDF5 Filter Integration Tests{Style.RESET_ALL}")
+    print(
+        f"{Fore.CYAN}{Style.BRIGHT}▶ FFMPEG HDF5 Filter Integration Tests{Style.RESET_ALL}"
+    )
     print(f"{Fore.CYAN}{'=' * 60}{Style.RESET_ALL}")
-    
+
     # Create test suite
     suite = unittest.TestLoader().loadTestsFromTestCase(TestIntegration)
-    
+
     # Run tests with colored output
     runner = ColoredTestRunner()
     result = runner.run(suite)
-    
+
     # Print summary
     print_summary("INTEGRATION TESTS", result)
     sys.exit(not result.wasSuccessful())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,50 +12,52 @@ import h5py
 from h5ffmpeg.utils import *
 
 
-def generate_3d_data(width=512, height=512, depth=100, dtype=np.uint8, pattern="random", seed=None):
+def generate_3d_data(
+    width=512, height=512, depth=100, dtype=np.uint8, pattern="random", seed=None
+):
     """
     Generate 3D volume test data.
     """
     if dtype not in [np.uint8, np.uint16]:
         raise ValueError("Only np.uint8 and np.uint16 data types are supported")
-    
+
     if seed is not None:
         np.random.seed(seed)
-    
+
     if pattern == "random":
         if dtype == np.uint8:
             return np.random.randint(0, 256, (depth, height, width), dtype=dtype)
         else:
             return np.random.randint(0, 65536, (depth, height, width), dtype=dtype)
-    
+
     elif pattern == "gradient":
         x = np.linspace(0, 1, width)
         y = np.linspace(0, 1, height)
         z = np.linspace(0, 1, depth)
-        xx, yy, zz = np.meshgrid(x, y, z, indexing='ij')
+        xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
         data = (xx + yy + zz) / 3
-        
+
         if dtype == np.uint8:
             data = (data * 255).astype(dtype)
         else:
             data = (data * 65535).astype(dtype)
-        
+
         return np.transpose(data, [2, 1, 0])
-    
+
     elif pattern == "stripes":
         x = np.arange(width)
         data = np.sin(x * 8 * np.pi / width)
         data = np.tile(data, (depth, height, 1))
-        
+
         data = (data + 1) / 2
-        
+
         if dtype == np.uint8:
             data = (data * 255).astype(dtype)
         else:
             data = (data * 65535).astype(dtype)
-        
-        return data  
-    
+
+        return data
+
     else:
         raise ValueError(f"Unknown pattern: {pattern}")
 
@@ -63,7 +65,7 @@ def generate_3d_data(width=512, height=512, depth=100, dtype=np.uint8, pattern="
 def test_codec_availability():
     """
     Test availability of each codec by attempting to use it for compression.
-    
+
     Returns:
     --------
     dict
@@ -75,10 +77,10 @@ def test_codec_availability():
     """
     # Import the codec convenience functions
     import h5ffmpeg as hf
-    
+
     # Generate a small test dataset
     test_data = generate_3d_data(width=164, height=164, depth=32, pattern="gradient")
-    
+
     # List of codec functions to test
     codec_functions = {
         "mpeg4": hf.mpeg4,
@@ -89,55 +91,55 @@ def test_codec_availability():
         "h264_nvenc": hf.h264_nvenc,
         "hevc_nvenc": hf.hevc_nvenc,
         "av1_nvenc": hf.av1_nvenc,
-        "av1_qsv": hf.av1_qsv
+        "av1_qsv": hf.av1_qsv,
     }
-    
+
     results = {}
-    
+
     # Test each codec
     for codec_name, codec_func in codec_functions.items():
         print(f"Testing {codec_name}...")
         results[codec_name] = {
-            'available': False,
-            'error': None,
-            'compression_ratio': None,
-            'psnr': None
+            "available": False,
+            "error": None,
+            "compression_ratio": None,
+            "psnr": None,
         }
-        
+
         try:
             # Get compression options using the convenience function
             compression_options = codec_func()
-            
+
             # Try to compress and decompress using the codec
             decompressed_data, compression_ratio, _, _, _ = compress_and_decompress(
                 test_data, compression_options
             )
-            
+
             # Calculate PSNR
             psnr = calculate_psnr(test_data, decompressed_data)
 
             if compression_ratio > 1:
                 # Update results
-                results[codec_name]['available'] = True
-                results[codec_name]['compression_ratio'] = compression_ratio
-                results[codec_name]['psnr'] = psnr
+                results[codec_name]["available"] = True
+                results[codec_name]["compression_ratio"] = compression_ratio
+                results[codec_name]["psnr"] = psnr
             else:
-                results[codec_name]['available'] = False
-                results[codec_name]['compression_ratio'] = 'n/a'
-                results[codec_name]['psnr'] = 'n/a'
-                results[codec_name]['error'] = 'See console above'
-            
+                results[codec_name]["available"] = False
+                results[codec_name]["compression_ratio"] = "n/a"
+                results[codec_name]["psnr"] = "n/a"
+                results[codec_name]["error"] = "See console above"
+
         except Exception as e:
             # Capture the error message
-            results[codec_name]['error'] = str(e)
-    
+            results[codec_name]["error"] = str(e)
+
     return results
 
 
 def get_available_codecs():
     """
     Get a list of available codecs.
-    
+
     Returns:
     --------
     dict
@@ -145,59 +147,66 @@ def get_available_codecs():
     """
     # Test all codecs
     test_results = test_codec_availability()
-    
+
     # Extract just the availability information
-    return {codec: results['available'] for codec, results in test_results.items()}
+    return {codec: results["available"] for codec, results in test_results.items()}
+
 
 def print_codec_availability():
     """
     Print a formatted report of codec availability with color highlighting,
     centered in the terminal window.
-    
+
     This is useful for diagnostic purposes and understanding
     which codecs are available on the current system.
     """
     import colorama
     from colorama import Fore, Back, Style
     import shutil  # For getting terminal size
-    
+
     # Initialize colorama for cross-platform color support
     colorama.init(autoreset=True)
-    
+
     results = test_codec_availability()
-    
+
     # Define constant widths
     TOTAL_WIDTH = 65  # Width of the report content
     CODEC_COL = 15
     AVAIL_COL = 11
     DESC_COL = 35
-    
+
     # Get terminal width
     terminal_width, _ = shutil.get_terminal_size()
-    
+
     # Calculate padding to center the report
     left_padding = max(0, (terminal_width - TOTAL_WIDTH) // 2)
-    padding = ' ' * left_padding
-    
+    padding = " " * left_padding
+
     # Helper function to ensure blue borders with colored content
     def blue_border_line(content, width=TOTAL_WIDTH):
         return f"{padding}{Style.BRIGHT}{Fore.BLUE}║{Style.RESET_ALL}{content}{Style.BRIGHT}{Fore.BLUE}║{Style.RESET_ALL}"
-    
+
     # Top border
-    print(f"\n{padding}{Style.BRIGHT}{Fore.BLUE}╔{'═' * (TOTAL_WIDTH - 2)}╗{Style.RESET_ALL}")
-    
+    print(
+        f"\n{padding}{Style.BRIGHT}{Fore.BLUE}╔{'═' * (TOTAL_WIDTH - 2)}╗{Style.RESET_ALL}"
+    )
+
     # Title
     title = "Codec Availability Report"
     title_padding = (TOTAL_WIDTH - len(title) - 2) // 2
     title_line = f"{' ' * title_padding}{title}{' ' * (TOTAL_WIDTH - len(title) - title_padding - 2)}"
     print(blue_border_line(title_line))
-    
+
     # Headers
-    print(f"{padding}{Style.BRIGHT}{Fore.BLUE}╠{'═' * CODEC_COL}╦{'═' * AVAIL_COL}╦{'═' * DESC_COL}╣{Style.RESET_ALL}")
+    print(
+        f"{padding}{Style.BRIGHT}{Fore.BLUE}╠{'═' * CODEC_COL}╦{'═' * AVAIL_COL}╦{'═' * DESC_COL}╣{Style.RESET_ALL}"
+    )
     header_line = f" {'Codec':<{CODEC_COL-2}} {Style.BRIGHT}{Fore.BLUE}║{Style.RESET_ALL} {'Available':<{AVAIL_COL-2}} {Style.BRIGHT}{Fore.BLUE}║{Style.RESET_ALL} {'Description':<{DESC_COL-2}} "
     print(blue_border_line(header_line))
-    print(f"{padding}{Style.BRIGHT}{Fore.BLUE}╠{'═' * CODEC_COL}╬{'═' * AVAIL_COL}╬{'═' * DESC_COL}╣{Style.RESET_ALL}")
-    
+    print(
+        f"{padding}{Style.BRIGHT}{Fore.BLUE}╠{'═' * CODEC_COL}╬{'═' * AVAIL_COL}╬{'═' * DESC_COL}╣{Style.RESET_ALL}"
+    )
+
     # Codec descriptions
     codec_descriptions = {
         "mpeg4": "MPEG-4 Part 2 visual codec (legacy)",
@@ -211,42 +220,46 @@ def print_codec_availability():
         "h264_qsv": "Intel QuickSync H.264 hardware encoding",
         "hevc_qsv": "Intel QuickSync H.265 hardware encoding",
         "av1_qsv": "Intel QuickSync AV1 hardware encoding",
-        "av1": "Generic AV1 implementation, newer standard"
+        "av1": "Generic AV1 implementation, newer standard",
     }
-    
+
     # Data rows
     for codec, result in results.items():
-        available = result['available']
-        
+        available = result["available"]
+
         # Get description instead of error
         description = codec_descriptions.get(codec, "General purpose video codec")
         if len(description) > DESC_COL - 2:
-            description = description[:DESC_COL - 5] + "..."
-        
+            description = description[: DESC_COL - 5] + "..."
+
         # Color coding: green for available, red for unavailable
         status_color = Fore.GREEN if available else Fore.RED
         status_text = "✓ Yes" if available else "✗ No"
-        
+
         # Use white for description text
         desc_color = Fore.WHITE
-        
+
         row_content = f" {Fore.CYAN}{codec:<{CODEC_COL-2}}{Style.RESET_ALL} {Style.BRIGHT}{Fore.BLUE}║{Style.RESET_ALL} {status_color}{status_text:<{AVAIL_COL-2}}{Style.RESET_ALL} {Style.BRIGHT}{Fore.BLUE}║{Style.RESET_ALL} {desc_color}{description:<{DESC_COL-2}}{Style.RESET_ALL} "
         print(blue_border_line(row_content))
-    
+
     # Separator
-    print(f"{padding}{Style.BRIGHT}{Fore.BLUE}╠{'═' * CODEC_COL}╩{'═' * AVAIL_COL}╩{'═' * DESC_COL}╣{Style.RESET_ALL}")
-    
+    print(
+        f"{padding}{Style.BRIGHT}{Fore.BLUE}╠{'═' * CODEC_COL}╩{'═' * AVAIL_COL}╩{'═' * DESC_COL}╣{Style.RESET_ALL}"
+    )
+
     # Available codecs section
-    available_codecs = [codec for codec, result in results.items() if result['available']]
-    
+    available_codecs = [
+        codec for codec, result in results.items() if result["available"]
+    ]
+
     if available_codecs:
         # Header for available codecs
         available_header = f" {Fore.GREEN}Available codecs:{' ' * (TOTAL_WIDTH - 20)}"
         print(blue_border_line(available_header))
-        
+
         # Available codecs list
         codec_list = ", ".join(available_codecs)
-        
+
         # Handle multi-line display if needed
         if len(codec_list) > TOTAL_WIDTH - 4:
             # Calculate how to split into multiple lines
@@ -254,9 +267,12 @@ def print_codec_availability():
             words = codec_list.split(", ")
             lines = []
             current_line = ""
-            
+
             for word in words:
-                if len(current_line) + len(word) + (2 if current_line else 0) <= max_line_length:
+                if (
+                    len(current_line) + len(word) + (2 if current_line else 0)
+                    <= max_line_length
+                ):
                     if current_line:
                         current_line += ", " + word
                     else:
@@ -264,10 +280,10 @@ def print_codec_availability():
                 else:
                     lines.append(current_line)
                     current_line = word
-            
+
             if current_line:
                 lines.append(current_line)
-            
+
             # Print each line
             for i, line in enumerate(lines):
                 prefix = "  " if i > 0 else " "
@@ -275,18 +291,23 @@ def print_codec_availability():
                 print(blue_border_line(codec_line))
         else:
             # Single line display
-            codec_line = f" {Fore.GREEN}{codec_list}{' ' * (TOTAL_WIDTH - len(codec_list) - 3)}"
+            codec_line = (
+                f" {Fore.GREEN}{codec_list}{' ' * (TOTAL_WIDTH - len(codec_list) - 3)}"
+            )
             print(blue_border_line(codec_line))
     else:
         # No codecs available
         no_codecs_line = f" {Fore.RED}No codecs available!{' ' * (TOTAL_WIDTH - 21)}"
         print(blue_border_line(no_codecs_line))
-    
+
     # Bottom border
-    print(f"{padding}{Style.BRIGHT}{Fore.BLUE}╚{'═' * (TOTAL_WIDTH - 2)}╝{Style.RESET_ALL}")
-    
+    print(
+        f"{padding}{Style.BRIGHT}{Fore.BLUE}╚{'═' * (TOTAL_WIDTH - 2)}╝{Style.RESET_ALL}"
+    )
+
     # Reset colorama settings
     colorama.deinit()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     print_codec_availability()


### PR DESCRIPTION
**DONE** 
1. Prevent SVT-AV1 info logging
2. Refactor array declaration
3. Fix formatting
4. Remove unused imports

**TODO** 
1. Set `__version__` from `setup.py` (currently hardcoded to `1.0.0`)
2. `size_t` should not be used to determine the file header size, because this can cause conflicts if a file is created on systems of different architectures (I don't think we are building for non-64 bit anyway?). The c memory model should use something like `uint64_t` which is platform agnostic.
* https://github.com/Cai-Lab-at-University-of-Michigan/ffmpeg_HDF5_filter/blob/f1ec503f3302448c38211955cb6b4bfd9d9343cd/h5ffmpeg/ffmpeg_filter.py#L668C9-L680C28
  